### PR TITLE
[codex] Add AI agent terminal workflow

### DIFF
--- a/.config/nvim/lua/common/ai_terminal.lua
+++ b/.config/nvim/lua/common/ai_terminal.lua
@@ -1,0 +1,82 @@
+local M = {}
+
+local state = {
+	agent_bufnr = nil,
+}
+
+local root_markers = {
+	".git",
+	"package.json",
+	"tsconfig.json",
+	"deno.json",
+	"deno.jsonc",
+	"go.mod",
+	"Cargo.toml",
+	"pyproject.toml",
+	"Gemfile",
+	"Makefile",
+}
+
+local function get_root()
+	local buf = vim.api.nvim_buf_get_name(0)
+	local start = buf ~= "" and vim.fs.dirname(buf) or vim.uv.cwd()
+	return vim.fs.root(start, root_markers) or vim.uv.cwd()
+end
+
+local function get_agent_command()
+	return vim.g.ai_agent_command or vim.env.AI_AGENT_CMD or "codex"
+end
+
+local function ensure_executable(command)
+	local executable = vim.split(command, "%s+")[1]
+	if vim.fn.executable(executable) == 0 then
+		vim.notify(("AI agent command not found: %s"):format(command), vim.log.levels.WARN)
+		return false
+	end
+
+	return true
+end
+
+function M.open_agent()
+	local command = get_agent_command()
+	if not ensure_executable(command) then
+		return
+	end
+
+	local cwd = get_root()
+	vim.cmd("botright vsplit")
+	vim.cmd("vertical resize 72")
+	vim.cmd(("lcd %s"):format(vim.fn.fnameescape(cwd)))
+	vim.cmd.terminal(command)
+	state.agent_bufnr = vim.api.nvim_get_current_buf()
+	vim.cmd.startinsert()
+end
+
+function M.open_shell()
+	local cwd = get_root()
+	vim.cmd("botright 12split")
+	vim.cmd(("lcd %s"):format(vim.fn.fnameescape(cwd)))
+	vim.cmd.terminal(vim.o.shell)
+	vim.cmd.startinsert()
+end
+
+function M.resume_agent()
+	if state.agent_bufnr and vim.api.nvim_buf_is_valid(state.agent_bufnr) then
+		local windows = vim.fn.win_findbuf(state.agent_bufnr)
+		if #windows > 0 then
+			vim.api.nvim_set_current_win(windows[1])
+			vim.cmd.startinsert()
+			return
+		end
+
+		vim.cmd("botright vsplit")
+		vim.cmd("vertical resize 72")
+		vim.api.nvim_set_current_buf(state.agent_bufnr)
+		vim.cmd.startinsert()
+		return
+	end
+
+	M.open_agent()
+end
+
+return M

--- a/.config/nvim/lua/common/keymap.lua
+++ b/.config/nvim/lua/common/keymap.lua
@@ -1,17 +1,42 @@
--- Leader key is set in init.lua
-
--- Basic key mappings
-vim.keymap.set("n", "<Leader>w", ":w<CR>", { noremap = true, silent = false })
-vim.keymap.set("i", "jj", "<ESC>", { noremap = true, silent = true })
-
--- Paste from yank register (register 0) to avoid pollution by d/c/x
 local opts = { noremap = true, silent = true }
+local ai_terminal = require("common.ai_terminal")
+
+vim.keymap.set("n", "<Leader>w", "<cmd>w<CR>", { desc = "Write file" })
+vim.keymap.set("n", "<Leader>q", "<cmd>q<CR>", { desc = "Quit window" })
+vim.keymap.set("n", "<Leader>Q", "<cmd>qa!<CR>", { desc = "Quit all" })
+vim.keymap.set("n", "<Leader>bd", "<cmd>bdelete<CR>", { desc = "Delete buffer" })
+vim.keymap.set("n", "<Leader>bo", function()
+	local current = vim.api.nvim_get_current_buf()
+	for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+		if buf ~= current and vim.bo[buf].buflisted then
+			pcall(vim.api.nvim_buf_delete, buf, { force = false })
+		end
+	end
+end, { desc = "Delete other buffers" })
+vim.keymap.set("n", "<Leader>e", "<cmd>Oil<CR>", { desc = "Open file explorer" })
+
+vim.keymap.set("i", "jj", "<ESC>", opts)
+
 vim.keymap.set("n", "<Leader>p", '"0p', opts)
 vim.keymap.set("n", "<Leader>P", '"0P', opts)
 vim.keymap.set("v", "<Leader>p", '"0p', opts)
 
--- Clear highlight
-vim.keymap.set("n", "<Esc><Esc>", ":noh<CR>", { noremap = true, silent = true })
+vim.keymap.set("n", "<Esc><Esc>", "<cmd>noh<CR>", { desc = "Clear highlight" })
+vim.keymap.set("n", "<Leader>,", "<cmd>Telescope buffers<CR>", { desc = "Buffers" })
+vim.keymap.set("n", "<Leader>/", "<cmd>Telescope current_buffer_fuzzy_find<CR>", { desc = "Search open buffer" })
+vim.keymap.set("n", "<Leader>:", "<cmd>Telescope command_history<CR>", { desc = "Command history" })
+vim.keymap.set("n", "<Leader>.", "<cmd>Telescope oldfiles<CR>", { desc = "Recent files" })
+vim.keymap.set("n", "[q", "<cmd>cprev<CR>", { desc = "Quickfix prev" })
+vim.keymap.set("n", "]q", "<cmd>cnext<CR>", { desc = "Quickfix next" })
+vim.keymap.set("n", "<Leader>xl", "<cmd>lopen<CR>", { desc = "Location list" })
+vim.keymap.set("n", "<Leader>xq", "<cmd>copen<CR>", { desc = "Quickfix list" })
 
--- Terminal escape
-vim.keymap.set("t", "<Esc>", "<c-\\><c-n>", { noremap = true, silent = true })
+vim.keymap.set("n", "<Leader>aa", ai_terminal.open_agent, { desc = "Open AI agent terminal" })
+vim.keymap.set("n", "<Leader>ar", ai_terminal.resume_agent, { desc = "Resume AI agent terminal" })
+vim.keymap.set("n", "<Leader>at", ai_terminal.open_shell, { desc = "Open project terminal" })
+
+vim.keymap.set("t", "<Esc>", "<C-\\><C-n>", opts)
+vim.keymap.set("t", "<C-h>", "<Cmd>wincmd h<CR>", opts)
+vim.keymap.set("t", "<C-j>", "<Cmd>wincmd j<CR>", opts)
+vim.keymap.set("t", "<C-k>", "<Cmd>wincmd k<CR>", opts)
+vim.keymap.set("t", "<C-l>", "<Cmd>wincmd l<CR>", opts)

--- a/.config/nvim/lua/plugins/ai.lua
+++ b/.config/nvim/lua/plugins/ai.lua
@@ -1,0 +1,30 @@
+return {
+	{
+		"folke/which-key.nvim",
+		event = "VeryLazy",
+		opts = {
+			preset = "modern",
+			delay = 200,
+			spec = {
+				{ "<leader>a", group = "ai/agent" },
+				{ "<leader>b", group = "buffer" },
+				{ "<leader>c", group = "code" },
+				{ "<leader>f", group = "find" },
+				{ "<leader>g", group = "git" },
+				{ "<leader>q", group = "quit/session" },
+				{ "<leader>t", group = "test/terminal" },
+				{ "<leader>x", group = "diagnostics" },
+			},
+		},
+	},
+	{
+		"christoomey/vim-tmux-navigator",
+		lazy = false,
+		keys = {
+			{ "<C-h>", "<cmd>TmuxNavigateLeft<CR>", desc = "Window left" },
+			{ "<C-j>", "<cmd>TmuxNavigateDown<CR>", desc = "Window down" },
+			{ "<C-k>", "<cmd>TmuxNavigateUp<CR>", desc = "Window up" },
+			{ "<C-l>", "<cmd>TmuxNavigateRight<CR>", desc = "Window right" },
+		},
+	},
+}

--- a/.config/nvim/lua/plugins/git.lua
+++ b/.config/nvim/lua/plugins/git.lua
@@ -45,10 +45,16 @@ return {
 		event = "InsertEnter",
 		config = function()
 			require("copilot").setup({
+				panel = {
+					enabled = false,
+				},
 				suggestion = {
 					auto_trigger = true,
 					keymap = {
-						accept = "<Tab>",
+						accept = "<M-l>",
+						next = "<M-]>",
+						prev = "<M-[>",
+						dismiss = "<C-]>",
 					},
 				},
 				copilot_node_command = vim.fn.expand("$HOME") .. "/.asdf/installs/nodejs/24.7.0/bin/node",
@@ -59,6 +65,8 @@ return {
 					gitcommit = true,
 				},
 			})
+
+			vim.keymap.set("n", "<Leader>ac", "<cmd>Copilot toggle<CR>", { desc = "Toggle Copilot" })
 		end,
 	},
 

--- a/.config/nvim/lua/plugins/init.lua
+++ b/.config/nvim/lua/plugins/init.lua
@@ -1,4 +1,5 @@
 return {
+	{ import = "plugins.ai" },
 	{ import = "plugins.editor" },
 	{ import = "plugins.completion" },
 	{ import = "plugins.git" },

--- a/README.md
+++ b/README.md
@@ -26,3 +26,15 @@ Copy the provided hook script to enable automatic Stylua checks when committing:
 cp scripts/pre-commit .git/hooks/pre-commit
 chmod +x .git/hooks/pre-commit
 ```
+
+## AI workflow
+
+- `<leader>aa`: open an AI agent terminal in the project root
+- `<leader>ar`: focus the existing AI agent terminal
+- `<leader>at`: open a project shell at the bottom
+
+The default AI agent command is `codex`. Override it with:
+
+```sh
+export AI_AGENT_CMD="your-agent-command"
+```


### PR DESCRIPTION
## What changed
- added a dedicated AI agent terminal helper that opens in the project root and can be resumed
- introduced `which-key` group labels and `vim-tmux-navigator` for better command discoverability and pane movement
- reorganized common keymaps around buffers, search, quickfix, and terminal flow
- moved Copilot accept off `<Tab>` and documented the new AI workflow in the README

## Why
The existing config had good plugin coverage but weak ergonomics for AI-assisted development. This PR makes it easy to keep an agent session open beside editing without giving up fast navigation.

## Impact
- `<leader>aa` opens an AI agent terminal
- `<leader>ar` jumps back to the running agent terminal
- `<leader>at` opens a project shell
- `<M-l>` accepts Copilot suggestions so `<Tab>` stays available for completion/snippets

## Validation
- `find .config/nvim -name '*.lua' -print0 | xargs -0 -n1 luac -p`
