### PR TITLE
[codex] Tune editor flow and completion

### DIFF
--- a/.config/nvim/lua/common/autocmd_config.lua
+++ b/.config/nvim/lua/common/autocmd_config.lua
@@ -10,18 +10,24 @@ vim.api.nvim_create_autocmd({ "TextYankPost" }, {
 	command = "silent! lua vim.highlight.on_yank{higroup='IncSearch', timeout=700}",
 })
 
+vim.api.nvim_create_autocmd({ "FocusGained", "TermClose", "TermLeave" }, {
+	pattern = "*",
+	command = "checktime",
+})
+
+vim.api.nvim_create_autocmd("TermOpen", {
+	pattern = "*",
+	callback = function()
+		vim.opt_local.number = false
+		vim.opt_local.relativenumber = false
+	end,
+})
+
 -- restore cursor shape
 -- https://vi.stackexchange.com/questions/25103/neovim-does-not-restore-terminal-cursor-on-exit
 vim.api.nvim_create_autocmd({ "VimLeave" }, {
 	pattern = { "*" },
 	command = "silent! lua vim.opt.guicursor = 'a:hor20'",
-})
-
-vim.api.nvim_create_autocmd("BufWritePre", {
-	pattern = "*",
-	callback = function(args)
-		require("conform").format({ bufnr = args.buf })
-	end,
 })
 
 -- join wrapped lines when yanking from terminal buffer (preserve empty lines as line breaks)

--- a/.config/nvim/lua/common/set_config.lua
+++ b/.config/nvim/lua/common/set_config.lua
@@ -1,7 +1,17 @@
--- basic
 vim.opt.confirm = true
 vim.opt.hidden = true
 vim.opt.number = true
+vim.opt.relativenumber = true
+vim.opt.cursorline = true
+vim.opt.signcolumn = "yes"
+vim.opt.splitbelow = true
+vim.opt.scrolloff = 6
+vim.opt.sidescrolloff = 8
+vim.opt.updatetime = 250
+vim.opt.timeoutlen = 300
+vim.opt.completeopt = { "menu", "menuone", "noselect" }
+vim.opt.winminwidth = 5
+vim.opt.pumheight = 12
 
 -- clipboard (OSC 52)
 vim.opt.clipboard = "unnamedplus"
@@ -18,6 +28,7 @@ vim.opt.hlsearch = true
 vim.opt.ignorecase = true
 vim.opt.smartcase = true
 vim.opt.smartindent = true
+vim.opt.infercase = true
 vim.opt.incsearch = true
 vim.opt.inccommand = "split"
 vim.opt.magic = true
@@ -37,5 +48,6 @@ vim.opt.whichwrap = "b,s,<,>,[,],h,l"
 vim.opt.mouse = ""
 
 vim.opt.swapfile = false
+vim.opt.undofile = true
 
 vim.opt.laststatus = 3

--- a/.config/nvim/lua/plugins/completion.lua
+++ b/.config/nvim/lua/plugins/completion.lua
@@ -6,28 +6,27 @@ return {
 			"hrsh7th/cmp-buffer",
 			"hrsh7th/cmp-path",
 			"hrsh7th/cmp-nvim-lsp",
+			"hrsh7th/cmp-nvim-lua",
+			"saadparwaiz1/cmp_luasnip",
 			"rafamadriz/friendly-snippets",
+			"L3MON4D3/LuaSnip",
 			"zbirenbaum/copilot-cmp",
 		},
 		config = function()
 			local cmp = require("cmp")
+			local luasnip = require("luasnip")
 
-			cmp.setup({
-				mapping = cmp.mapping.preset.insert({
-					["<C-k>"] = cmp.mapping.select_prev_item(),
-					["<C-j>"] = cmp.mapping.select_next_item(),
-					["<C-b>"] = cmp.mapping.scroll_docs(-4),
-					["<C-f>"] = cmp.mapping.scroll_docs(4),
-					["<C-Space>"] = cmp.mapping.complete(),
-					["<C-e>"] = cmp.mapping.abort(),
-					["<CR>"] = cmp.mapping.confirm({ select = true }),
-				}),
-				sources = cmp.config.sources({
-					{ name = "copilot", priority = 1000 },
-					{ name = "nvim_lsp", priority = 900 },
-					{ name = "path", priority = 700 },
-				}, {
-					{
+			require("luasnip.loaders.from_vscode").lazy_load()
+			require("copilot_cmp").setup()
+
+			local sources = cmp.config.sources({
+				{ name = "copilot", priority = 1000 },
+				{ name = "nvim_lsp", priority = 900 },
+				{ name = "luasnip", priority = 850 },
+				{ name = "path", priority = 700 },
+				{ name = "nvim_lua", priority = 650 },
+			}, {
+				{
 					name = "buffer",
 					priority = 600,
 					option = {
@@ -42,14 +41,54 @@ return {
 						end,
 					},
 				},
+			})
+
+			cmp.setup({
+				snippet = {
+					expand = function(args)
+						luasnip.lsp_expand(args.body)
+					end,
+				},
+				mapping = cmp.mapping.preset.insert({
+					["<C-k>"] = cmp.mapping.select_prev_item(),
+					["<C-j>"] = cmp.mapping.select_next_item(),
+					["<C-b>"] = cmp.mapping.scroll_docs(-4),
+					["<C-f>"] = cmp.mapping.scroll_docs(4),
+					["<C-Space>"] = cmp.mapping.complete(),
+					["<C-e>"] = cmp.mapping.abort(),
+					["<Tab>"] = cmp.mapping(function(fallback)
+						if cmp.visible() then
+							cmp.select_next_item()
+						elseif luasnip.expand_or_locally_jumpable() then
+							luasnip.expand_or_jump()
+						else
+							fallback()
+						end
+					end, { "i", "s" }),
+					["<S-Tab>"] = cmp.mapping(function(fallback)
+						if cmp.visible() then
+							cmp.select_prev_item()
+						elseif luasnip.locally_jumpable(-1) then
+							luasnip.jump(-1)
+						else
+							fallback()
+						end
+					end, { "i", "s" }),
+					["<CR>"] = cmp.mapping.confirm({ select = true }),
 				}),
+				sources = sources,
+				experimental = {
+					ghost_text = true,
+				},
 				formatting = {
 					format = function(entry, vim_item)
 						vim_item.menu = ({
 							copilot = "[Copilot]",
 							nvim_lsp = "[LSP]",
+							luasnip = "[Snippet]",
 							buffer = "[Buffer]",
 							path = "[Path]",
+							nvim_lua = "[Lua]",
 						})[entry.source.name]
 						return vim_item
 					end,
@@ -60,6 +99,13 @@ return {
 	{
 		"windwp/nvim-autopairs",
 		event = "InsertEnter",
-		opts = {},
+		config = function()
+			local autopairs = require("nvim-autopairs")
+			local cmp_autopairs = require("nvim-autopairs.completion.cmp")
+			local cmp = require("cmp")
+
+			autopairs.setup({})
+			cmp.event:on("confirm_done", cmp_autopairs.on_confirm_done())
+		end,
 	},
 }

--- a/.config/nvim/lua/plugins/editor.lua
+++ b/.config/nvim/lua/plugins/editor.lua
@@ -3,11 +3,30 @@ return {
 		"stevearc/conform.nvim",
 		event = "BufWritePre",
 		opts = {
+			notify_on_error = true,
+			format_on_save = function(bufnr)
+				if vim.g.disable_autoformat or vim.b[bufnr].disable_autoformat then
+					return
+				end
+
+				return {
+					timeout_ms = 1500,
+					lsp_format = "fallback",
+				}
+			end,
 			formatters_by_ft = {
 				lua = { "stylua" },
 				-- Use a sub-list to run only the first available formatter
 				javascript = { "prettierd", "prettier" },
 				typescript = { "prettierd", "prettier" },
+				javascriptreact = { "prettierd", "prettier" },
+				typescriptreact = { "prettierd", "prettier" },
+				json = { "prettierd", "prettier" },
+				yaml = { "prettierd", "prettier" },
+				markdown = { "prettierd", "prettier" },
+				sh = { "shfmt" },
+				ruby = { "rubocop" },
+				python = { "ruff_format", "black" },
 				go = { "gofmt" },
 			},
 		},
@@ -16,12 +35,26 @@ return {
 		"mfussenegger/nvim-lint",
 		event = { "BufReadPost", "BufWritePost" },
 		config = function()
-			require("lint").linters_by_ft = {
+			local lint = require("lint")
+
+			lint.linters_by_ft = {
 				javascript = { "eslint" },
 				typescript = { "eslint" },
+				javascriptreact = { "eslint" },
+				typescriptreact = { "eslint" },
 				lua = { "luacheck" },
 				ruby = { "rubocop" },
+				python = { "ruff" },
+				go = { "golangcilint" },
 			}
+
+			local lint_augroup = vim.api.nvim_create_augroup("nvim-lint", { clear = true })
+			vim.api.nvim_create_autocmd({ "BufEnter", "BufWritePost", "InsertLeave" }, {
+				group = lint_augroup,
+				callback = function()
+					lint.try_lint()
+				end,
+			})
 		end,
 	},
 	{
@@ -69,6 +102,18 @@ return {
 			statuscolumn = { enabled = true },
 			terminal = { enabled = true },
 			words = { enabled = true },
+		},
+		keys = {
+			{
+				"<Leader>ft",
+				"<cmd>TodoTelescope<CR>",
+				desc = "Find TODOs",
+			},
+			{
+				"<Leader>fr",
+				"<cmd>Telescope resume<CR>",
+				desc = "Resume picker",
+			},
 		},
 	},
 	{


### PR DESCRIPTION
## What changed
- tightened core editor options for movement, timing, popup behavior, and window layout
- added terminal/file refresh autocmds and simplified formatting-on-save through `conform`
- expanded formatter/linter coverage for common languages used in this config
- upgraded completion with LuaSnip, snippet sources, ghost text, and autopairs integration

## Why
Most of the friction in AI-assisted development is not model quality but edit-loop latency. This PR improves the local editing loop so accepting suggestions, formatting changes, and jumping between files is more predictable.

## Impact
- better insert-mode completion and snippet expansion
- format-on-save is centrally controlled and easier to disable per buffer
- linting runs on buffer enter, save, and insert leave instead of only on open/save
- terminal buffers behave more cleanly and external file changes are detected sooner

## Validation
- `find .config/nvim -name '*.lua' -print0 | xargs -0 -n1 luac -p`
