### PR TITLE
[codex] Improve LSP diagnostics workflow

### DIFF
--- a/.config/nvim/lua/plugins/configs/lspconfig.lua
+++ b/.config/nvim/lua/plugins/configs/lspconfig.lua
@@ -3,6 +3,21 @@ return function()
 
 	local capabilities = require("cmp_nvim_lsp").default_capabilities()
 
+	vim.diagnostic.config({
+		severity_sort = true,
+		virtual_text = {
+			spacing = 2,
+			source = "if_many",
+		},
+		float = {
+			border = "single",
+			source = "if_many",
+		},
+		signs = true,
+		underline = true,
+		update_in_insert = false,
+	})
+
 	-- 全サーバー共通の設定
 	vim.lsp.config("*", {
 		capabilities = capabilities,
@@ -11,22 +26,31 @@ return function()
 	vim.api.nvim_create_autocmd("LspAttach", {
 		callback = function(args)
 			local bufopts = { noremap = true, silent = true, buffer = args.buf }
+			local client = vim.lsp.get_client_by_id(args.data.client_id)
 
 			vim.keymap.set("n", "gd", vim.lsp.buf.definition, bufopts)
 			vim.keymap.set("n", "gD", vim.lsp.buf.declaration, bufopts)
-			vim.keymap.set("n", "gl", vim.lsp.buf.references, bufopts)
+			vim.keymap.set("n", "gr", vim.lsp.buf.references, bufopts)
 			vim.keymap.set("n", "K", vim.lsp.buf.hover, bufopts)
-			vim.keymap.set("n", "gr", vim.lsp.buf.rename, bufopts)
-			vim.keymap.set("n", "ga", vim.lsp.buf.code_action, bufopts)
 			vim.keymap.set("n", "gi", vim.lsp.buf.implementation, bufopts)
+			vim.keymap.set("n", "gt", vim.lsp.buf.type_definition, bufopts)
+			vim.keymap.set("n", "<Leader>ca", vim.lsp.buf.code_action, bufopts)
+			vim.keymap.set("n", "<Leader>cr", vim.lsp.buf.rename, bufopts)
+			vim.keymap.set("n", "<Leader>cl", vim.diagnostic.open_float, bufopts)
+			vim.keymap.set("n", "<Leader>cs", "<cmd>Telescope lsp_document_symbols<CR>", bufopts)
+			vim.keymap.set("n", "<Leader>cS", "<cmd>Telescope lsp_dynamic_workspace_symbols<CR>", bufopts)
 
 			vim.keymap.set("n", "]d", vim.diagnostic.goto_next, bufopts)
 			vim.keymap.set("n", "[d", vim.diagnostic.goto_prev, bufopts)
 
-			vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, {
-				border = "single",
-			})
+			if client and client:supports_method("textDocument/inlayHint") then
+				vim.lsp.inlay_hint.enable(true, { bufnr = args.buf })
+			end
 		end,
+	})
+
+	vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, {
+		border = "single",
 	})
 
 	-- サーバー固有の設定（カスタマイズが必要なもののみ）
@@ -65,6 +89,10 @@ return function()
 		},
 	})
 
+	vim.lsp.config("ruby_lsp", {
+		root_markers = { "Gemfile", ".git" },
+	})
+
 	vim.lsp.config("eslint", {
 		settings = {
 			workingDirectory = { mode = "auto" },
@@ -91,4 +119,5 @@ return function()
 	vim.lsp.enable("sorbet")
 	vim.lsp.enable("flow")
 	vim.lsp.enable("hls")
+	vim.lsp.enable("ruby_lsp")
 end


### PR DESCRIPTION
## What changed
- configured diagnostics with better float/virtual text defaults and severity sorting
- moved rename and code actions onto explicit `<leader>` mappings while restoring `gr` for references
- added document/workspace symbol pickers and type-definition navigation
- enabled inlay hints automatically for servers that support them and added `ruby_lsp`

## Why
The current LSP setup worked, but the navigation semantics were inconsistent and important diagnostics actions were harder to reach quickly. This PR makes code navigation more predictable during review and refactor loops.

## Impact
- `gr` is references again
- `<leader>ca` triggers code actions
- `<leader>cr` renames symbols
- `<leader>cl`, `<leader>cs`, and `<leader>cS` expose diagnostics and symbols faster

## Validation
- `find .config/nvim -name '*.lua' -print0 | xargs -0 -n1 luac -p`
