### PR TITLE
fix: make lualine branch worktree-aware

### DIFF
--- a/.config/nvim/lua/plugins/configs/lualine.lua
+++ b/.config/nvim/lua/plugins/configs/lualine.lua
@@ -1,8 +1,83 @@
+-- cwd-based branch resolver. The default lualine `branch` component walks
+-- upward from the current buffer's filename, which fails on unnamed buffers
+-- inside a worktree (e.g. fresh `<leader>gwa` tab) because the search escapes
+-- the worktree and finds the main repo's `.git` instead.
+local sep = "/"
+
+local function find_git_dir_for(dir)
+	while dir and dir ~= "" and dir ~= "/" do
+		local git_path = dir .. sep .. ".git"
+		local stat = vim.loop.fs_stat(git_path)
+		if stat then
+			if stat.type == "directory" then
+				return git_path
+			elseif stat.type == "file" then
+				local f = io.open(git_path)
+				if f then
+					local line = f:read("*l")
+					f:close()
+					if line then
+						local gd = line:match("^gitdir:%s*(.+)$")
+						if gd then
+							if gd:sub(1, 1) ~= sep then
+								gd = dir .. sep .. gd
+							end
+							return gd
+						end
+					end
+				end
+			end
+		end
+		local parent = dir:match("^(.*)/[^/]+$")
+		if not parent or parent == dir then
+			return nil
+		end
+		dir = parent
+	end
+end
+
+local function read_branch(git_dir)
+	if not git_dir then
+		return ""
+	end
+	local f = io.open(git_dir .. "/HEAD")
+	if not f then
+		return ""
+	end
+	local head = f:read("*l")
+	f:close()
+	if not head then
+		return ""
+	end
+	local b = head:match("^ref: refs/heads/(.+)$")
+	if b then
+		return b
+	end
+	return head:sub(1, 7)
+end
+
+local cache = { cwd = nil, branch = "" }
+
+local function worktree_branch()
+	local cwd = vim.fn.getcwd()
+	if cwd ~= cache.cwd then
+		cache.cwd = cwd
+		cache.branch = read_branch(find_git_dir_for(cwd))
+	end
+	return cache.branch
+end
+
+vim.api.nvim_create_autocmd({ "DirChanged", "TabEnter", "FocusGained", "ShellCmdPost" }, {
+	callback = function()
+		cache.cwd = nil
+	end,
+})
+
 return function()
 	require("lualine").setup({
 		sections = {
 			lualine_a = {},
-			lualine_b = { { "branch", icon = "" } },
+			lualine_b = { { worktree_branch, icon = "" } },
 			lualine_c = {
 				{ "filename", file_status = true, path = 1, separator = "" },
 				{ "diff" },


### PR DESCRIPTION
## Summary
- `<leader>gwa` / `<leader>gws` で worktree タブに移動しても、status line の branch が main のままになることがあった。
- 原因は lualine 標準の `branch` コンポーネントが `expand('%:p:h')` 起点で `.git` を上向き探索する仕様で、`claude://<cwd>` という buffer 名に当たると `:h` が偽パスを返し、解決失敗 → global state が壊れて以後ずれていた。
- buffer 名ではなく tab-local `getcwd()` を起点にする自前 resolver に差替え。`.git` が file の場合は `gitdir:` 行を読んで worktree gitdir に resolve、その HEAD をパースする。cwd 単位のキャッシュ + `DirChanged / TabEnter / FocusGained / ShellCmdPost` で invalidate。

## Test plan
- [x] `luac -p` 通過
- [x] headless で `cwd=.worktrees/hoge` → ` hoge`、`cwd=main` → ` main` を確認
- [ ] 実環境で `<leader>gwa` 直後 / `<leader>gws` 切替後に正しいブランチが表示されること
- [ ] claude pane に focus 後も他タブの表示が壊れないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)