### PR TITLE
worktree: タスク文 → claude がブランチ名を決めて作業開始

### DIFF
--- a/.config/nvim/lua/plugins/configs/worktree.lua
+++ b/.config/nvim/lua/plugins/configs/worktree.lua
@@ -182,4 +182,85 @@ function M.review_pr_with_claude()
 	end)
 end
 
+local function sanitize_branch(name)
+	name = name:gsub('^["`\']+', ""):gsub('["`\']+$', "")
+	name = name:gsub("^%s+", ""):gsub("%s+$", "")
+	-- git refs forbid spaces and many specials; keep only the safe set.
+	name = name:gsub("[^A-Za-z0-9_/%-]+", "-")
+	name = name:gsub("%-+", "-"):gsub("^%-", ""):gsub("%-$", "")
+	return name
+end
+
+local function suggest_branch_name(task, on_done)
+	local prompt = table.concat({
+		"Suggest ONE short kebab-case git branch name for this task.",
+		"Output ONLY the branch name on a single line — no quotes,",
+		"no prefix like 'feature/' or 'fix/', no explanation, no markdown fence.",
+		"Keep it under 40 characters and ASCII only.",
+		"",
+		"Task: " .. task,
+	}, "\n")
+
+	vim.notify("claude: choosing a branch name…")
+	vim.system(
+		{ "claude", "-p", prompt },
+		{ text = true },
+		vim.schedule_wrap(function(out)
+			if out.code ~= 0 then
+				vim.notify(
+					"claude -p failed (exit " .. tostring(out.code) .. "): " .. (out.stderr or ""),
+					vim.log.levels.ERROR
+				)
+				return
+			end
+			local first
+			for line in (out.stdout or ""):gmatch("[^\r\n]+") do
+				if line:match("%S") then
+					first = line
+					break
+				end
+			end
+			local branch = first and sanitize_branch(first) or ""
+			if branch == "" then
+				vim.notify("claude returned no usable branch name", vim.log.levels.ERROR)
+				return
+			end
+			on_done(branch)
+		end)
+	)
+end
+
+local function create_from_task(from_default)
+	local prompt = from_default and "Task (claude picks branch, from default): "
+		or "Task (claude picks branch): "
+	input(prompt, function(task)
+		suggest_branch_name(task, function(branch)
+			vim.ui.input({
+				prompt = "Create worktree with branch: ",
+				default = branch,
+			}, function(confirmed)
+				if not confirmed or confirmed == "" then
+					return
+				end
+				local create_cmd = "GitWorktreeCreate " .. confirmed
+				if from_default then
+					create_cmd = create_cmd .. " --from-default"
+				end
+				in_new_tab(function()
+					vim.cmd(create_cmd)
+					claude().open({ prompt = task })
+				end)
+			end)
+		end)
+	end)
+end
+
+function M.create_with_task()
+	create_from_task(false)
+end
+
+function M.create_from_default_with_task()
+	create_from_task(true)
+end
+
 return M

--- a/.config/nvim/lua/plugins/git.lua
+++ b/.config/nvim/lua/plugins/git.lua
@@ -98,6 +98,20 @@ return {
 				end,
 				desc = "Worktree: review PR + claude --from-pr",
 			},
+			{
+				"<leader>gwt",
+				function()
+					require("plugins.configs.worktree").create_with_task()
+				end,
+				desc = "Worktree: task -> claude picks branch + opens claude",
+			},
+			{
+				"<leader>gwT",
+				function()
+					require("plugins.configs.worktree").create_from_default_with_task()
+				end,
+				desc = "Worktree: task (from default) -> claude picks branch + opens claude",
+			},
 			{ "<leader>gwX", "<cmd>GitWorktreeCleanup<CR>", desc = "Worktree: cleanup all" },
 		},
 	},

--- a/doc/worktree-workflow.md
+++ b/doc/worktree-workflow.md
@@ -18,6 +18,8 @@
 | `<leader>gwa`  | 新規 worktree 作成 + claude を起動         |
 | `<leader>gwA`  | default branch 起点で作成 + claude         |
 | `<leader>gwR`  | PR レビュー用 worktree + `claude --from-pr`|
+| `<leader>gwt`  | タスク文を渡して claude にブランチ名を決めさせ作業開始 |
+| `<leader>gwT`  | `<leader>gwt` の default branch 起点版     |
 | `<leader>gwX`  | 現在以外の worktree を一括削除（確認あり） |
 
 Telescope picker（`<leader>gws`）では `<C-d>` で削除も可能。
@@ -102,6 +104,10 @@ worktree 作成時の `--command` 経由でも呼べる:
 - `<leader>gwR` — PR レビュー: 当該 PR の worktree を作り、その上で
   `claude --from-pr <num>` を起動。Claude が PR にひも付いた既存セッションを
   あれば再開、なければ新規作成する
+- `<leader>gwt` — ブランチ名の代わりに「やりたいこと」を入力。`claude -p`
+  を裏で叩いて kebab-case のブランチ名候補を1つもらい、その候補（編集可）
+  で確定すると worktree が作られ、claude にそのタスク文がそのまま初期
+  prompt として渡される。`<leader>gwT` は default branch 起点版。
 
 ### セッション継続
 


### PR DESCRIPTION
## Summary
- `<leader>gwt` / `<leader>gwT` を追加。ブランチ名ではなく「やりたいこと」を入力すると、`claude -p` が裏で kebab-case のブランチ名候補を1つ返し、確認 (編集可) のうえ worktree を作成して claude を起動する
- `claude_term.open({ prompt = task })` で task 文をそのまま初期 prompt として渡すので、worktree が開いた直後からその内容で作業が始まる
- `doc/worktree-workflow.md` のキーマップ表と説明を更新

## Test plan
- [ ] `<leader>gwt` で適当なタスク文 (例: "add dark mode toggle") を入力 → 候補ブランチ名が表示されて編集確定で worktree が作られる
- [ ] 新しいタブの cwd が新 worktree、claude が task 文を初期 prompt として開いている
- [ ] `<leader>gwT` も同様で、起点が default branch になっている
- [ ] `claude` が PATH に無い / 失敗した場合に notify(ERROR) が出る
- [ ] 候補が既存 branch と被るとき、確認ステップで名前を編集して回避できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)