### PR TITLE
Telescope picker for terminal-only buffers

### DIFF
--- a/.config/nvim/lua/plugins/configs/telescope.lua
+++ b/.config/nvim/lua/plugins/configs/telescope.lua
@@ -1,3 +1,63 @@
+-- Mirrors telescope.builtin.buffers but pre-filters to terminal buffers.
+local function pick_terminal_buffers(opts)
+	opts = opts or {}
+	local pickers = require("telescope.pickers")
+	local finders = require("telescope.finders")
+	local conf = require("telescope.config").values
+	local make_entry = require("telescope.make_entry")
+	local actions = require("telescope.actions")
+	local action_state = require("telescope.actions.state")
+
+	local bufnrs = {}
+	for _, b in ipairs(vim.api.nvim_list_bufs()) do
+		if vim.api.nvim_buf_is_valid(b) and vim.bo[b].buftype == "terminal" then
+			table.insert(bufnrs, b)
+		end
+	end
+	if not next(bufnrs) then
+		vim.notify("No terminal buffers", vim.log.levels.INFO)
+		return
+	end
+
+	table.sort(bufnrs, function(a, b)
+		return vim.fn.getbufinfo(a)[1].lastused > vim.fn.getbufinfo(b)[1].lastused
+	end)
+
+	local current = vim.api.nvim_get_current_buf()
+	local alternate = vim.fn.bufnr("#")
+	local buffers = {}
+	for _, bufnr in ipairs(bufnrs) do
+		local flag = bufnr == current and "%" or (bufnr == alternate and "#" or " ")
+		table.insert(buffers, {
+			bufnr = bufnr,
+			flag = flag,
+			info = vim.fn.getbufinfo(bufnr)[1],
+		})
+	end
+
+	pickers
+		.new(opts, {
+			prompt_title = "🖥  Terminal Buffers",
+			finder = finders.new_table({
+				results = buffers,
+				entry_maker = opts.entry_maker or make_entry.gen_from_buffer(opts),
+			}),
+			sorter = conf.generic_sorter(opts),
+			previewer = conf.grep_previewer(opts),
+			attach_mappings = function(prompt_bufnr, _)
+				actions.select_default:replace(function()
+					local entry = action_state.get_selected_entry()
+					actions.close(prompt_bufnr)
+					if entry and entry.bufnr and vim.api.nvim_buf_is_valid(entry.bufnr) then
+						vim.api.nvim_set_current_buf(entry.bufnr)
+					end
+				end)
+				return true
+			end,
+		})
+		:find()
+end
+
 return function()
 	local actions = require("telescope.actions")
 	local mappings = {
@@ -96,6 +156,12 @@ return function()
 		{ noremap = true, silent = false }
 	)
 	vim.keymap.set("n", ";", "<cmd>Telescope buffers<CR>", { noremap = true, silent = false })
+	vim.api.nvim_create_user_command("TelescopeTerminals", function()
+		pick_terminal_buffers()
+	end, { desc = "Telescope picker over terminal buffers only" })
+	vim.keymap.set("n", "<Leader>;", function()
+		pick_terminal_buffers()
+	end, { noremap = true, silent = true, desc = "Telescope: terminal buffers only" })
 	-- vim.keymap.set(
 	-- 	"n",
 	-- 	";",


### PR DESCRIPTION
## Summary
- `<Leader>;` (and `:TelescopeTerminals`) で `buftype == "terminal"` の buffer だけを Telescope picker で表示
- worktree ごとに立てた claude terminal の切り替えで `;` のノイズを避けるのが目的
- `telescope.builtin.buffers` を踏襲（MRU ソート、`%` / `#` フラグ、`make_entry.gen_from_buffer` の見た目）

## Test plan
- [ ] `;` は今まで通り全 buffer を表示する
- [ ] terminal を 1 つも開いていない状態で `<Leader>;` を押すと `No terminal buffers` が出る
- [ ] `<leader>cc` で claude terminal を開いた worktree が複数あるとき、`<Leader>;` でその一覧が出て選択でジャンプできる
- [ ] `:TelescopeTerminals` でも同じ picker が出る

🤖 Generated with [Claude Code](https://claude.com/claude-code)