### PR TITLE
fix(keymap): drop legacy <leader>gw mappings shadowing gw prefix

### DIFF
--- a/.config/nvim/lua/plugins/editor.lua
+++ b/.config/nvim/lua/plugins/editor.lua
@@ -30,9 +30,6 @@ return {
 		cmd = "Telescope",
 		keys = {
 			{ "<Leader>fp", "<cmd>Telescope possession<CR>", desc = "Telescope possession" },
-			{ "<Leader>gw", "<cmd>Telescope git_worktree<CR>", desc = "Git worktree" },
-			{ "<Leader>gwc", ":GitWorktreeCreate", desc = "Git worktree create" },
-			{ "<Leader>gwr", ":GitWorktreeReview", desc = "Git worktree review" },
 			{ "<Leader>fs", "<cmd>Telescope server servers<CR>", desc = "Server list" },
 			{ "<Leader>fsl", "<cmd>Telescope server logs<CR>", desc = "Server logs" },
 		},


### PR DESCRIPTION
## Summary
- `editor.lua` の telescope.nvim spec に残っていた `<Leader>gw` 単独マップが、`git.lua` の `<leader>gw{t,a,c,s,...}` と prefix 衝突していた。完全マップが成立するため `timeoutlen` 内に後続キーを打たないと Telescope picker が起動してしまい、`<leader>gwt` などが体感「動かない／落ちる」状態だった。
- 併せて `<Leader>gwc` / `<Leader>gwr` も `<CR>` 無しの壊れたマップだったので削除（`git.lua` に正しい代替が揃っている）。

## Test plan
- [x] `nvim --headless -c "Lazy load git_worktree.nvim telescope.nvim" -c "verbose nmap <leader>gw"` で `<Space>gw` 単独マップが消え、`gwt / gwT / gwa / gwA / gws / gwc / gwC / gwd / gwl / gw. / gwr / gwR / gwX` のみが残ることを確認。
- [ ] 実機 nvim で `<leader>gwt` を押下 → タスク入力プロンプトが timeout 待ちなく即発火することを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)