### PR TITLE
chore(plugins): remove possession.nvim integration

### DIFF
--- a/.config/nvim/lua/plugins/configs/lualine.lua
+++ b/.config/nvim/lua/plugins/configs/lualine.lua
@@ -110,11 +110,6 @@ return function()
 					separator = "",
 				},
 				{ "diagnostics", sources = { "nvim_diagnostic" } },
-				{
-					function()
-						return require("possession.session").get_session_name() or ""
-					end,
-				},
 			},
 			lualine_x = { "encoding", "fileformat", "filetype" },
 			lualine_y = { "progress" },

--- a/.config/nvim/lua/plugins/configs/telescope.lua
+++ b/.config/nvim/lua/plugins/configs/telescope.lua
@@ -170,7 +170,6 @@ return function()
 	-- )
 
 	-- load telescope extensions
-	require("telescope").load_extension("possession")
 	require("telescope").load_extension("git_worktree")
 	require("telescope").load_extension("server")
 end

--- a/.config/nvim/lua/plugins/editor.lua
+++ b/.config/nvim/lua/plugins/editor.lua
@@ -29,7 +29,6 @@ return {
 		lazy = false,
 		cmd = "Telescope",
 		keys = {
-			{ "<Leader>fp", "<cmd>Telescope possession<CR>", desc = "Telescope possession" },
 			{ "<Leader>fs", "<cmd>Telescope server servers<CR>", desc = "Server list" },
 			{ "<Leader>fsl", "<cmd>Telescope server logs<CR>", desc = "Server logs" },
 		},
@@ -147,22 +146,6 @@ return {
 				require("dial.map").manipulate("decrement", "normal")
 			end)
 		end,
-	},
-	{
-		"jedrzejboczar/possession.nvim",
-		event = "BufReadPost",
-		opts = {
-			autosave = {
-				current = true,
-				cwd = function()
-					return not require("possession.session").exists(require("possession.paths").cwd_session_name())
-				end,
-			},
-			autoload = "auto_cwd",
-			plugins = {
-				delete_buffers = true,
-			},
-		},
 	},
 	{
 		"rhysd/accelerated-jk",


### PR DESCRIPTION
## Summary
- Remove `jedrzejboczar/possession.nvim` plugin spec along with its autosave/autoload/`delete_buffers` opts.
- Drop the `<Leader>fp` → `Telescope possession` keymap and the `load_extension("possession")` call.
- Remove the lualine component that displayed the current possession session name.

## Test plan
- [ ] `nvim` boots cleanly with no missing-module errors from lualine / telescope.
- [ ] `:Lazy` no longer lists `possession.nvim`.
- [ ] `<Leader>fp` no longer triggers Telescope possession (mapping is gone).
- [ ] Lualine renders without the session-name segment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)