### PR TITLE
feat(plugins): add which-key.nvim for keymap discovery

### DIFF
--- a/.config/nvim/lua/plugins/editor.lua
+++ b/.config/nvim/lua/plugins/editor.lua
@@ -196,6 +196,34 @@ return {
 		},
 	},
 	{
+		"folke/which-key.nvim",
+		event = "VeryLazy",
+		init = function()
+			vim.o.timeout = true
+			vim.o.timeoutlen = 300
+		end,
+		opts = {
+			preset = "modern",
+			spec = {
+				{ "<leader>f", group = "find" },
+				{ "<leader>g", group = "git" },
+				{ "<leader>gw", group = "worktree" },
+				{ "<leader>t", group = "test" },
+				{ "<leader>x", group = "trouble" },
+				{ "<leader>a", group = "aerial / any-jump" },
+			},
+		},
+		keys = {
+			{
+				"<leader>?",
+				function()
+					require("which-key").show({ global = false })
+				end,
+				desc = "Buffer Keymaps (which-key)",
+			},
+		},
+	},
+	{
 		"folke/todo-comments.nvim",
 		event = "BufReadPost",
 		dependencies = { "nvim-lua/plenary.nvim" },


### PR DESCRIPTION
## Summary
- Add `folke/which-key.nvim` (lazy on `VeryLazy`) with `preset = "modern"`.
- Register group labels for existing leader prefixes: `<leader>f` find, `<leader>g` git, `<leader>gw` worktree, `<leader>t` test, `<leader>x` trouble, `<leader>a` aerial / any-jump.
- Add `<leader>?` → `which-key.show({ global = false })` for a buffer-local keymap browser.
- Set `timeout = true` / `timeoutlen = 300` inside the plugin's `init`, so the change is scoped to when which-key loads (no edits to global `init.lua` / `set_config.lua`).

## Test plan
- [ ] Open Neovim; confirm which-key loads on `VeryLazy` without errors.
- [ ] Press `<leader>` and verify the group labels appear with the registered names.
- [ ] Press `<leader>?` and confirm the buffer-local keymap browser opens.
- [ ] Existing keymaps with `desc` (telescope, vim-test, aerial, flash, todo-comments, worktree) show their descriptions.
- [ ] Confirm `:set timeoutlen?` reports `300` only after which-key has loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)