### PR TITLE
feat(which-key): add server prefix groups and surface desc fields

### DIFF
--- a/.config/nvim/lua/common/keymap.lua
+++ b/.config/nvim/lua/common/keymap.lua
@@ -1,17 +1,16 @@
 -- Leader key is set in init.lua
 
 -- Basic key mappings
-vim.keymap.set("n", "<Leader>w", ":w<CR>", { noremap = true, silent = false })
-vim.keymap.set("i", "jj", "<ESC>", { noremap = true, silent = true })
+vim.keymap.set("n", "<Leader>w", ":w<CR>", { noremap = true, silent = false, desc = "Write file" })
+vim.keymap.set("i", "jj", "<ESC>", { noremap = true, silent = true, desc = "Exit insert mode" })
 
 -- Paste from yank register (register 0) to avoid pollution by d/c/x
-local opts = { noremap = true, silent = true }
-vim.keymap.set("n", "<Leader>p", '"0p', opts)
-vim.keymap.set("n", "<Leader>P", '"0P', opts)
-vim.keymap.set("v", "<Leader>p", '"0p', opts)
+vim.keymap.set("n", "<Leader>p", '"0p', { noremap = true, silent = true, desc = 'Paste from "0 (after)' })
+vim.keymap.set("n", "<Leader>P", '"0P', { noremap = true, silent = true, desc = 'Paste from "0 (before)' })
+vim.keymap.set("v", "<Leader>p", '"0p', { noremap = true, silent = true, desc = 'Paste from "0' })
 
 -- Clear highlight
-vim.keymap.set("n", "<Esc><Esc>", ":noh<CR>", { noremap = true, silent = true })
+vim.keymap.set("n", "<Esc><Esc>", ":noh<CR>", { noremap = true, silent = true, desc = "Clear search highlight" })
 
 -- Terminal escape
-vim.keymap.set("t", "<Esc>", "<c-\\><c-n>", { noremap = true, silent = true })
+vim.keymap.set("t", "<Esc>", "<c-\\><c-n>", { noremap = true, silent = true, desc = "Exit terminal mode" })

--- a/.config/nvim/lua/plugins/editor.lua
+++ b/.config/nvim/lua/plugins/editor.lua
@@ -75,8 +75,18 @@ return {
 		"tyru/columnskip.vim",
 		event = "VeryLazy",
 		config = function()
-			vim.keymap.set("n", "<Leader>j", "<Plug>(columnskip:nonblank:next)", { noremap = false, silent = true })
-			vim.keymap.set("n", "<Leader>k", "<Plug>(columnskip:nonblank:prev)", { noremap = false, silent = true })
+			vim.keymap.set(
+				"n",
+				"<Leader>j",
+				"<Plug>(columnskip:nonblank:next)",
+				{ noremap = false, silent = true, desc = "Column skip down (non-blank)" }
+			)
+			vim.keymap.set(
+				"n",
+				"<Leader>k",
+				"<Plug>(columnskip:nonblank:prev)",
+				{ noremap = false, silent = true, desc = "Column skip up (non-blank)" }
+			)
 		end,
 	},
 	{
@@ -91,15 +101,20 @@ return {
 			vim.g.any_jump_disable_default_keybindings = "1"
 		end,
 		config = function()
-			vim.keymap.set("n", "<Leader>an", ":AnyJump<CR>", { noremap = true, silent = false })
+			vim.keymap.set(
+				"n",
+				"<Leader>an",
+				":AnyJump<CR>",
+				{ noremap = true, silent = false, desc = "AnyJump: jump to definition" }
+			)
 		end,
 	},
 	{
 		"t9md/vim-quickhl",
 		event = "BufReadPost",
 		keys = {
-			{ "<Leader>h", "<Plug>(quickhl-manual-this)", mode = "n" },
-			{ "<Leader>H", "<Plug>(quickhl-manual-reset)", mode = "n" },
+			{ "<Leader>h", "<Plug>(quickhl-manual-this)", mode = "n", desc = "Quickhl: highlight word" },
+			{ "<Leader>H", "<Plug>(quickhl-manual-reset)", mode = "n", desc = "Quickhl: clear" },
 		},
 	},
 	{
@@ -206,8 +221,10 @@ return {
 			preset = "modern",
 			spec = {
 				{ "<leader>f", group = "find" },
+				{ "<leader>fs", group = "server" },
 				{ "<leader>g", group = "git" },
 				{ "<leader>gw", group = "worktree" },
+				{ "<leader>s", group = "server / flash" },
 				{ "<leader>t", group = "test" },
 				{ "<leader>x", group = "trouble" },
 				{ "<leader>a", group = "aerial / any-jump" },

--- a/.config/nvim/lua/plugins/util.lua
+++ b/.config/nvim/lua/plugins/util.lua
@@ -7,8 +7,8 @@ return {
 		"vim-test/vim-test",
 		event = "BufReadPost",
 		keys = {
-			{ "<Leader>tn", ":TestNearest RAILS_ENV=test<CR>", mode = "n" },
-			{ "<Leader>tf", ":TestFile RAILS_ENV=test<CR>", mode = "n" },
+			{ "<Leader>tn", ":TestNearest RAILS_ENV=test<CR>", mode = "n", desc = "Test: nearest" },
+			{ "<Leader>tf", ":TestFile RAILS_ENV=test<CR>", mode = "n", desc = "Test: file" },
 		},
 		config = function()
 			vim.api.nvim_set_var("test#strategy", "neovim")


### PR DESCRIPTION
## Summary
- Add `<leader>fs` (server) and `<leader>s` (server / flash) prefix groups to the which-key spec, reflecting the server-terminal bindings introduced in `lua/common/server.lua`.
- Fill in missing `desc` fields on existing mappings (`keymap.lua`, columnskip, any-jump, quickhl, vim-test) so they render with meaningful labels in which-key, `:Telescope keymaps`, and `:map`.
- Drop the shared `local opts` in `keymap.lua` so each `vim.keymap.set` carries its own `desc`.

## Test plan
- [ ] Open Neovim, press `<leader>` and confirm groups appear with the new labels (`server`, `server / flash`).
- [ ] Press `<leader>?` to view buffer keymaps and verify the new `desc` strings show on `<Leader>w`, `<Leader>p/P`, columnskip `<Leader>j/k`, quickhl `<Leader>h/H`, any-jump `<Leader>an`, vim-test `<Leader>tn/tf`.
- [ ] Sanity-check that `<leader>s` server bindings (`ss`, `sS`, `st`, `sx`, `sr`) still trigger after the spec change, and that Flash (`<leader>s` alone) still fires after `timeoutlen=300`.

## Note
`<leader>s` now hosts both Flash (single-press) and the server prefix; with `timeoutlen=300` Flash incurs a brief wait. Worth a follow-up to move Flash to a dedicated key — out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)