### PR TITLE
feat(ui): add bufferline.nvim as a tab page bar

### DIFF
--- a/.config/nvim/lua/common/set_config.lua
+++ b/.config/nvim/lua/common/set_config.lua
@@ -33,8 +33,9 @@ vim.opt.virtualedit = "block"
 vim.opt.backspace = "indent,eol,start"
 vim.opt.whichwrap = "b,s,<,>,[,],h,l"
 
--- disable mouse
-vim.opt.mouse = ""
+-- mouse: normal mode only — enables tabline (bufferline) click without
+-- hijacking selection/copy in insert & visual modes.
+vim.opt.mouse = "n"
 
 vim.opt.swapfile = false
 

--- a/.config/nvim/lua/plugins/ui.lua
+++ b/.config/nvim/lua/plugins/ui.lua
@@ -130,4 +130,36 @@ return {
 		event = "BufReadPost",
 		opts = {},
 	},
+	-- Tab page bar: shows Vim tabs (each tab ≈ a worktree in this config).
+	-- Labels render the tab's cwd basename so a worktree tab reads as the
+	-- branch/dir name (e.g. `add_tab_bar_plugin`) instead of the active buffer.
+	{
+		"akinsho/bufferline.nvim",
+		version = "*",
+		event = "VeryLazy",
+		dependencies = { "nvim-tree/nvim-web-devicons" },
+		opts = {
+			options = {
+				mode = "tabs",
+				style_preset = "default",
+				diagnostics = "nvim_lsp",
+				show_buffer_close_icons = false,
+				show_close_icon = false,
+				separator_style = "thin",
+				always_show_bufferline = true,
+				indicator = { style = "underline" },
+				name_formatter = function(opts)
+					local tabnr = opts.tabnr
+					if tabnr then
+						local cwd = vim.fn.getcwd(-1, tabnr)
+						local label = vim.fn.fnamemodify(cwd, ":t")
+						if label ~= "" then
+							return label
+						end
+					end
+					return opts.name
+				end,
+			},
+		},
+	},
 }


### PR DESCRIPTION
## なに

worktree=tab で運用しているため、Vim の tab pages を見やすく可視化する tabbar として `akinsho/bufferline.nvim` を **tabs モード** で導入します。

## ポイント

- `mode = "tabs"` — buffer 一覧ではなく Vim の tab pages を表示
- `name_formatter` で各 tab の `getcwd(-1, tabnr)` のベース名をラベル化
  → worktree tab がブランチ名相当（例: `add_tab_bar_plugin`）で読める
- `diagnostics = "nvim_lsp"` で LSP 診断件数も tab に表示
- `indicator.style = "underline"` で現在 tab を下線表示
- close icon は非表示（`:tabclose` 想定で誤クリック防止）

## マウス操作

`common/set_config.lua` の `vim.opt.mouse` を `""` → `"n"` に変更。
normal モードだけ有効なので tabbar クリック切替が効き、insert/visual でのトラックパッド選択コピーは従来通り。

## キー操作

新しいキーマップは追加していません（`<Leader>t*` は既に test と衝突するため）。tab 切替は Vim 標準の `gt` / `gT` がそのまま使えます。

## 動作確認

- `nvim --headless -u NONE -c "luafile .config/nvim/lua/plugins/ui.lua" -c qa` で Lua syntax OK
- 実機での見栄えは nvim 再起動後、lazy が bufferline を取得した時点で反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)