### PR TITLE
feat(telescope): scope buffer pickers to the current worktree tab

### DIFF
--- a/.config/nvim/lua/plugins/configs/telescope.lua
+++ b/.config/nvim/lua/plugins/configs/telescope.lua
@@ -1,4 +1,39 @@
--- Mirrors telescope.builtin.buffers but pre-filters to terminal buffers.
+local function normalize_path(p)
+	if not p or p == "" then
+		return ""
+	end
+	return (vim.fn.fnamemodify(p, ":p"):gsub("/+$", ""))
+end
+
+-- Each worktree tab pins itself with `tcd`, so the tab's local cwd uniquely
+-- identifies the worktree. Treat that cwd as the grouping key.
+local function tab_cwd()
+	return normalize_path(vim.fn.getcwd(-1, 0))
+end
+
+local function buf_under(buf, base)
+	if base == "" then
+		return true
+	end
+	local name = vim.api.nvim_buf_get_name(buf)
+	if name == "" then
+		return false
+	end
+	-- Terminal buffers carry their launch cwd in the name: term://CWD//PID:CMD.
+	if vim.bo[buf].buftype == "terminal" then
+		local term_cwd = name:match("^term://(.-)//")
+		if not term_cwd then
+			return false
+		end
+		name = normalize_path(term_cwd)
+	else
+		name = normalize_path(name)
+	end
+	return name == base or name:sub(1, #base + 1) == base .. "/"
+end
+
+-- Mirrors telescope.builtin.buffers but pre-filters to terminal buffers
+-- belonging to the current worktree tab.
 local function pick_terminal_buffers(opts)
 	opts = opts or {}
 	local pickers = require("telescope.pickers")
@@ -8,14 +43,19 @@ local function pick_terminal_buffers(opts)
 	local actions = require("telescope.actions")
 	local action_state = require("telescope.actions.state")
 
+	local cwd = tab_cwd()
 	local bufnrs = {}
 	for _, b in ipairs(vim.api.nvim_list_bufs()) do
-		if vim.api.nvim_buf_is_valid(b) and vim.bo[b].buftype == "terminal" then
+		if
+			vim.api.nvim_buf_is_valid(b)
+			and vim.bo[b].buftype == "terminal"
+			and buf_under(b, cwd)
+		then
 			table.insert(bufnrs, b)
 		end
 	end
 	if not next(bufnrs) then
-		vim.notify("No terminal buffers", vim.log.levels.INFO)
+		vim.notify("No terminal buffers in this worktree", vim.log.levels.INFO)
 		return
 	end
 
@@ -37,7 +77,7 @@ local function pick_terminal_buffers(opts)
 
 	pickers
 		.new(opts, {
-			prompt_title = "🖥  Terminal Buffers",
+			prompt_title = "🖥  Terminal Buffers (worktree)",
 			finder = finders.new_table({
 				results = buffers,
 				entry_maker = opts.entry_maker or make_entry.gen_from_buffer(opts),
@@ -155,13 +195,21 @@ return function()
 		"<cmd>lua Snacks.picker.grep({ hidden = true })<CR>",
 		{ noremap = true, silent = false }
 	)
-	vim.keymap.set("n", ";", "<cmd>Telescope buffers<CR>", { noremap = true, silent = false })
+	-- Each worktree pins its tab via `tcd`, so cwd_only = true scopes the buffer
+	-- list to just the buffers opened inside this worktree. Use <Leader>: to
+	-- escape the grouping when you really want everything.
+	vim.keymap.set("n", ";", function()
+		require("telescope.builtin").buffers({ cwd_only = true })
+	end, { noremap = true, silent = false, desc = "Telescope: buffers in current worktree" })
+	vim.keymap.set("n", "<Leader>:", function()
+		require("telescope.builtin").buffers()
+	end, { noremap = true, silent = false, desc = "Telescope: all buffers (every worktree)" })
 	vim.api.nvim_create_user_command("TelescopeTerminals", function()
 		pick_terminal_buffers()
 	end, { desc = "Telescope picker over terminal buffers only" })
 	vim.keymap.set("n", "<Leader>;", function()
 		pick_terminal_buffers()
-	end, { noremap = true, silent = true, desc = "Telescope: terminal buffers only" })
+	end, { noremap = true, silent = true, desc = "Telescope: terminal buffers in current worktree" })
 	-- vim.keymap.set(
 	-- 	"n",
 	-- 	";",


### PR DESCRIPTION
## なに

worktree ごとに `:tabnew` + `tcd` で tab を分けても Neovim の buffer は global なので、
`;` (`Telescope buffers`) を開くと他の worktree の buffer まで出ていた。これを現 tab
の cwd 配下に絞り、worktree 単位で grouping されたように振る舞わせる。

## どうやって

各 worktree tab は既に `tcd` で tab-local cwd に固定されているので `vim.uv.cwd()` が
worktree のパスを返す。Telescope 内蔵の `cwd_only = true` がこの cwd プレフィックスで
buffer をフィルタしてくれるので、これに乗る。terminal 用ピッカーも同じ思想で揃え、
`term://CWD//PID:CMD` の CWD 部分を tab cwd と比較してフィルタする。

## キーマップ

| key | 振る舞い |
| --- | --- |
| `;` | 現 worktree の buffer のみ (`cwd_only = true`) |
| `<Leader>:` *(新規)* | 全 worktree の buffer（逃げ道） |
| `<Leader>;` / `:TelescopeTerminals` | 現 worktree の terminal buffer のみ |

## 注意

`cwd_only` はバッファ名のプレフィックス一致なので、unnamed buffer や worktree 外で
開いたファイル (例: `~/.config/nvim/...`) は `;` に出ない。その用途は `<Leader>:` で。

🤖 Generated with [Claude Code](https://claude.com/claude-code)