### PR TITLE
fix(neogit): open in current window instead of new tab

### DIFF
--- a/.config/nvim/lua/plugins/git.lua
+++ b/.config/nvim/lua/plugins/git.lua
@@ -10,7 +10,15 @@ return {
 			-- Only one of these is needed, not both.
 			"ibhagwan/fzf-lua", -- optional
 		},
-		opts = {},
+		-- Neogit defaults to `kind = "tab"`, which spawns a new Vim tab page.
+		-- That collides with bufferline.nvim's `mode = "tabs"` setup (see
+		-- ui.lua): a worktree tab and the Neogit tab share the same cwd, so
+		-- they render with the same name_formatter label and the tab-aware
+		-- `<leader>gws` picker can't tell them apart. Replace the current
+		-- buffer instead — `:q` returns to the prior buffer.
+		opts = {
+			kind = "replace",
+		},
 	},
 	{
 		"lewis6991/gitsigns.nvim",


### PR DESCRIPTION
## Why

bufferline.nvim is configured with `mode = "tabs"` (see `ui.lua`), so the
tab line shows each Vim tab page — one per worktree in this setup. Neogit
defaults to `kind = "tab"`, which spawns a brand new Vim tab on every
`:Neogit` invocation.

That collides badly with the worktree-tab workflow:
- The Neogit tab inherits the source worktree's cwd, so bufferline's
  `name_formatter` (basename of `getcwd(-1, tabnr)`) labels it identically
  to the worktree tab it came from.
- `<leader>gws` (tab-aware switch, `lua/plugins/configs/worktree.lua`)
  matches tabs by cwd and can't tell the two apart.

## What

Set `opts.kind = "replace"` on the neogit spec. `:Neogit` now replaces
the current window's buffer; `:q` returns to the prior buffer. No new
tab page is created, so bufferline's tab column stays one-per-worktree.

Sub-views (`commit_editor`, `log_view`, `refs_view`, popups, …) carry
their own `kind` settings, all of which default to non-tab kinds
(floating / split / vsplit) in upstream Neogit. No further overrides
needed.

## Verification

- `luac -p .config/nvim/lua/plugins/git.lua` passes
- Headless smoke:
  ```
  nvim --headless -c "Lazy load neogit" \
    -c 'lua print(require("neogit.config").values.kind)' -c qa
  ```
  prints `replace`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)