### PR TITLE
fix(ui): guard bufferline name_formatter against stale tabnr

### DIFF
--- a/.config/nvim/lua/plugins/ui.lua
+++ b/.config/nvim/lua/plugins/ui.lua
@@ -149,12 +149,18 @@ return {
 				always_show_bufferline = true,
 				indicator = { style = "underline" },
 				name_formatter = function(opts)
+					-- Closing a tab can cause bufferline to re-render with a
+					-- stale `tabnr` that no longer exists. `vim.fn.getcwd(-1, tabnr)`
+					-- raises E5000 in that case, surfacing as E5108. Guard with a
+					-- range check and pcall, falling back to the buffer name.
 					local tabnr = opts.tabnr
-					if tabnr then
-						local cwd = vim.fn.getcwd(-1, tabnr)
-						local label = vim.fn.fnamemodify(cwd, ":t")
-						if label ~= "" then
-							return label
+					if tabnr and tabnr >= 1 and tabnr <= vim.fn.tabpagenr("$") then
+						local ok, cwd = pcall(vim.fn.getcwd, -1, tabnr)
+						if ok then
+							local label = vim.fn.fnamemodify(cwd, ":t")
+							if label ~= "" then
+								return label
+							end
 						end
 					end
 					return opts.name


### PR DESCRIPTION
## 症状

タブを閉じた直後にエラーバナーが出る:

```
E5108: Lua: Vim:E5000: Cannot find tab number.
stack traceback:
        [C]: in function 'getcwd'
        .../lua/plugins/ui.lua:154: in function 'name_formatter'
        ...bufferline.nvim/lua/bufferline/models.lua:121: in function 'new'
        ...bufferline.nvim/lua/bufferline/tabpages.lua:143: in function 'get_components'
        ...bufferline.nvim/lua/bufferline.lua:56
```

## 原因

`bufferline.nvim` はタブ閉鎖直後の再描画で、すでに存在しない `tabnr` を
`name_formatter` に渡してくることがある。`vim.fn.getcwd(-1, tabnr)` は
そのときに `E5000` を投げるため、Lua 側で `E5108` として表面化する。
特に `<leader>gwq` (`worktree.close_tabs`) で複数タブを一括クローズ
する流れで踏みやすい。

## 修正

`.config/nvim/lua/plugins/ui.lua` の `name_formatter`:

- `tabnr` が `1..vim.fn.tabpagenr("$")` の範囲か先にチェック
- `vim.fn.getcwd` を `pcall` で囲み、失敗時は `opts.name` にフォール
  バック

ラベルが一瞬 buffer 名になるだけで、エラーは出なくなる。

## 動作確認

- `stylua --check` 通過
- タブ閉鎖時の E5108 再現 → 消失を確認（実機）

🤖 Generated with [Claude Code](https://claude.com/claude-code)