### PR TITLE
feat(worktree): show PR # / state next to each branch in `<leader>gws`

### DIFF
--- a/.config/nvim/lua/plugins/configs/worktree.lua
+++ b/.config/nvim/lua/plugins/configs/worktree.lua
@@ -70,6 +70,55 @@ local function list_worktrees()
 	return result
 end
 
+-- Returns { [branch] = { number, state, isDraft } } from `gh pr list`.
+-- Empty on any failure (gh missing, not a GH repo, network down).
+local function fetch_prs_by_branch()
+	if vim.fn.executable("gh") ~= 1 then
+		return {}
+	end
+	local out = vim.fn.systemlist({
+		"gh",
+		"pr",
+		"list",
+		"--state",
+		"all",
+		"--json",
+		"number,headRefName,state,isDraft",
+		"--limit",
+		"200",
+	})
+	if vim.v.shell_error ~= 0 then
+		return {}
+	end
+	local ok, decoded = pcall(vim.json.decode, table.concat(out, "\n"))
+	if not ok or type(decoded) ~= "table" then
+		return {}
+	end
+	-- gh returns newest first; keep the most recent entry per branch so a
+	-- reopened branch shows its current PR rather than an old merged one.
+	local by_branch = {}
+	for _, pr in ipairs(decoded) do
+		if pr.headRefName and not by_branch[pr.headRefName] then
+			by_branch[pr.headRefName] = pr
+		end
+	end
+	return by_branch
+end
+
+local function format_pr_label(pr)
+	if not pr then
+		return ""
+	end
+	if pr.state == "OPEN" then
+		return pr.isDraft and string.format("#%d(D)", pr.number) or string.format("#%d", pr.number)
+	end
+	if pr.state == "MERGED" then
+		return string.format("#%d(M)", pr.number)
+	end
+	-- CLOSED (un-merged): not surfaced.
+	return ""
+end
+
 --- Switch to a tab already pinned to `path`, or open a new tab pinned to it.
 function M.switch_to(path, branch)
 	local existing = find_tab_for(path)
@@ -93,6 +142,10 @@ function M.switch()
 	local actions = require("telescope.actions")
 	local action_state = require("telescope.actions.state")
 
+	-- One synchronous `gh` call per picker invocation; misses (no gh, offline)
+	-- degrade to an empty map and an empty PR column rather than failing.
+	local prs = fetch_prs_by_branch()
+
 	pickers
 		.new({}, {
 			prompt_title = "Git Worktrees (tab-aware)",
@@ -108,10 +161,12 @@ function M.switch()
 					else
 						prefix = "  "
 					end
+					local pr_label = format_pr_label(prs[entry.branch])
+					local display = string.format("%s%-24s %-8s %s", prefix, entry.branch, pr_label, entry.path)
 					return {
 						value = entry,
-						display = prefix .. entry.display,
-						ordinal = entry.branch .. " " .. entry.path,
+						display = display,
+						ordinal = entry.branch .. " " .. pr_label .. " " .. entry.path,
 					}
 				end,
 			}),

--- a/doc/worktree-workflow.md
+++ b/doc/worktree-workflow.md
@@ -23,6 +23,10 @@
 | `<leader>gwX`  | 現在以外の worktree を一括削除（確認あり） |
 
 Telescope picker（`<leader>gws`）では `<C-d>` で削除も可能。
+各行はこの並びで表示される: `<状態> <branch> <PR ラベル> <path>`。`<状態>` は
+`*`（現 cwd）/ `T`（既にタブで開いている）/ ` `（その他）。`<PR ラベル>` は
+`gh pr list` の結果から、open は `#25`、draft は `#25(D)`、merged は `#25(M)`、
+PR 無し / closed は空欄。`gh` 未インストール・未認証時は全行で空欄になる。
 
 実体は
 [`lua/plugins/configs/worktree.lua`](../.config/nvim/lua/plugins/configs/worktree.lua)


### PR DESCRIPTION
## 概要

`<leader>gws` の Telescope picker (`M.switch()` in `lua/plugins/configs/worktree.lua`) で、各 worktree の branch のすぐ右に対応する GitHub PR のラベルを表示するようにしました。

```
* worktree_pr_show         #-       /Users/.../.worktrees/worktree_pr_show
T close_tab_quick          #25(M)   /Users/.../.worktrees/close_tab_quick
  add_tab_bar_plugin       #22(M)   /Users/.../.worktrees/add_tab_bar_plugin
  feature_x                #41      /Users/.../.worktrees/feature_x
```

## ラベルの読み方

| PR の状態 | 表示 |
| ---- | ---- |
| OPEN | `#25` |
| OPEN + draft | `#25(D)` |
| MERGED | `#25(M)` |
| CLOSED (un-merged) / PR 無し | 空欄 |

## 実装メモ

- `fetch_prs_by_branch()` 新規。`gh pr list --state all --json number,headRefName,state,isDraft --limit 200` を `vim.fn.systemlist` で同期実行 → `vim.json.decode` で `{ [headRefName] = pr }` を返す。
- `format_pr_label(pr)` 新規。上の表のラベル整形だけを担当する純粋関数。
- `M.switch()` の entry_maker に PR ラベル列を追加。`ordinal` にもラベルを混ぜたので、prompt に `25` と打って PR #25 のブランチに飛べる。
- 同じ branch で複数 PR が紐づく場合は gh が新しい順に返すので最初の 1 件 (= 現役) を採用。
- 退化挙動: `gh` 未インストール / 未認証 / 非 GitHub repo / network down / JSON parse 失敗、すべて `{}` を返してラベル列が空欄になるだけで picker は壊れない。
- `close_tabs` 系の経路 (`branch_by_cwd` → `list_worktrees`) は触らず、`gh` 呼び出しは switch 経路に閉じてある。

## 動作確認

- `luac -p .config/nvim/lua/plugins/configs/worktree.lua` 通過
- `XDG_CONFIG_HOME=... nvim --headless` 経由で `require("plugins.configs.worktree")` → `switch / close_tabs` ともに `function`
- `format_pr_label` を nil / OPEN / draft / MERGED / CLOSED の 5 入力で叩いて期待ラベル (`""` / `#42` / `#7(D)` / `#25(M)` / `""`)
- 実 `gh pr list` JSON shape をシェルで確認済み

## ドキュメント

`doc/worktree-workflow.md` の `<leader>gws` 説明に行レイアウトと PR ラベル仕様を追記。

🤖 Generated with [Claude Code](https://claude.com/claude-code)