### PR TITLE
fix(telescope): include terminal buffers in `;` picker

### DIFF
--- a/.config/nvim/lua/plugins/configs/telescope.lua
+++ b/.config/nvim/lua/plugins/configs/telescope.lua
@@ -19,9 +19,11 @@ local function buf_under(buf, base)
 	if name == "" then
 		return false
 	end
-	-- Terminal buffers carry their launch cwd in the name: term://CWD//PID:CMD.
+	-- Terminal buffers carry their launch cwd in the name. Two schemes:
+	--   term://CWD//PID:CMD       (default :terminal / jobstart-term)
+	--   claude://CWD              (renamed by plugins/configs/claude_term.lua)
 	if vim.bo[buf].buftype == "terminal" then
-		local term_cwd = name:match("^term://(.-)//")
+		local term_cwd = name:match("^term://(.-)//") or name:match("^claude://(.*)$")
 		if not term_cwd then
 			return false
 		end
@@ -32,9 +34,11 @@ local function buf_under(buf, base)
 	return name == base or name:sub(1, #base + 1) == base .. "/"
 end
 
--- Mirrors telescope.builtin.buffers but pre-filters to terminal buffers
--- belonging to the current worktree tab.
-local function pick_terminal_buffers(opts)
+-- Mirrors telescope.builtin.buffers but uses buf_under() to scope to the
+-- current worktree tab. Unlike telescope's `cwd_only`, this understands
+-- terminal URI schemes (term://, claude://) so terminal buffers are
+-- included instead of silently filtered out by raw name-prefix matching.
+local function pick_buffers(opts)
 	opts = opts or {}
 	local pickers = require("telescope.pickers")
 	local finders = require("telescope.finders")
@@ -43,19 +47,27 @@ local function pick_terminal_buffers(opts)
 	local actions = require("telescope.actions")
 	local action_state = require("telescope.actions.state")
 
+	local terminal_only = opts.terminal_only
 	local cwd = tab_cwd()
 	local bufnrs = {}
 	for _, b in ipairs(vim.api.nvim_list_bufs()) do
-		if
-			vim.api.nvim_buf_is_valid(b)
-			and vim.bo[b].buftype == "terminal"
-			and buf_under(b, cwd)
-		then
-			table.insert(bufnrs, b)
+		if vim.api.nvim_buf_is_valid(b) and buf_under(b, cwd) then
+			local include
+			if terminal_only then
+				include = vim.bo[b].buftype == "terminal"
+			else
+				include = vim.fn.buflisted(b) == 1
+			end
+			if include then
+				table.insert(bufnrs, b)
+			end
 		end
 	end
 	if not next(bufnrs) then
-		vim.notify("No terminal buffers in this worktree", vim.log.levels.INFO)
+		vim.notify(
+			terminal_only and "No terminal buffers in this worktree" or "No buffers in this worktree",
+			vim.log.levels.INFO
+		)
 		return
 	end
 
@@ -77,7 +89,7 @@ local function pick_terminal_buffers(opts)
 
 	pickers
 		.new(opts, {
-			prompt_title = "🖥  Terminal Buffers (worktree)",
+			prompt_title = terminal_only and "🖥  Terminal Buffers (worktree)" or "✨ Search Buffers ✨",
 			finder = finders.new_table({
 				results = buffers,
 				entry_maker = opts.entry_maker or make_entry.gen_from_buffer(opts),
@@ -195,20 +207,20 @@ return function()
 		"<cmd>lua Snacks.picker.grep({ hidden = true })<CR>",
 		{ noremap = true, silent = false }
 	)
-	-- Each worktree pins its tab via `tcd`, so cwd_only = true scopes the buffer
-	-- list to just the buffers opened inside this worktree. Use <Leader>: to
-	-- escape the grouping when you really want everything.
+	-- Each worktree pins its tab via `tcd`, so scoping to tab cwd narrows the
+	-- buffer list to just the buffers opened inside this worktree. Use
+	-- <Leader>: to escape the grouping when you really want everything.
 	vim.keymap.set("n", ";", function()
-		require("telescope.builtin").buffers({ cwd_only = true })
+		pick_buffers()
 	end, { noremap = true, silent = false, desc = "Telescope: buffers in current worktree" })
 	vim.keymap.set("n", "<Leader>:", function()
 		require("telescope.builtin").buffers()
 	end, { noremap = true, silent = false, desc = "Telescope: all buffers (every worktree)" })
 	vim.api.nvim_create_user_command("TelescopeTerminals", function()
-		pick_terminal_buffers()
+		pick_buffers({ terminal_only = true })
 	end, { desc = "Telescope picker over terminal buffers only" })
 	vim.keymap.set("n", "<Leader>;", function()
-		pick_terminal_buffers()
+		pick_buffers({ terminal_only = true })
 	end, { noremap = true, silent = true, desc = "Telescope: terminal buffers in current worktree" })
 	-- vim.keymap.set(
 	-- 	"n",


### PR DESCRIPTION
## Summary
- `;` was using `telescope.builtin.buffers({ cwd_only = true })`, whose filter only does a literal cwd prefix match against the buffer name — so `term://CWD//PID:CMD` and `claude://CWD` buffers were silently filtered out.
- Routed `;` and `<Leader>;` through a unified `pick_buffers(opts)` that uses the existing `buf_under()` URI-aware filter, with `opts.terminal_only` selecting between "all buffers in this worktree" and "terminal buffers only".
- Extended `buf_under()` to recognize the `claude://` URI scheme used by `lua/plugins/configs/claude_term.lua` (previously only `term://` was understood).
- `<Leader>:` (escape hatch to all buffers across worktrees) is left untouched.

Closes #29

## Test plan
- [x] `stylua --check` / `luac -p` clean
- [x] Regex unit check: `claude://CWD`, `claude://CWD/sub`, `term://CWD//PID:CMD`, and a normal file path all parse as expected
- [x] Headless `nvim --headless` confirms `setup()` runs and `;` / `<Leader>;` are bound to the new picker
- [ ] Manual: open a worktree, launch claude (`<leader>cc`), press `;` and confirm the claude terminal shows up alongside file buffers
- [ ] Manual: `<leader>;` still narrows to terminal buffers only

🤖 Generated with [Claude Code](https://claude.com/claude-code)