### PR TITLE
chore(config): disable mouse in all modes

### DIFF
--- a/.config/nvim/lua/common/set_config.lua
+++ b/.config/nvim/lua/common/set_config.lua
@@ -33,9 +33,8 @@ vim.opt.virtualedit = "block"
 vim.opt.backspace = "indent,eol,start"
 vim.opt.whichwrap = "b,s,<,>,[,],h,l"
 
--- mouse: normal mode only — enables tabline (bufferline) click without
--- hijacking selection/copy in insert & visual modes.
-vim.opt.mouse = "n"
+-- mouse: disabled in all modes.
+vim.opt.mouse = ""
 
 vim.opt.swapfile = false
 


### PR DESCRIPTION
## Summary
- Disable mouse operations across all Neovim modes by changing `vim.opt.mouse` from `"n"` (normal mode only) to `""`.

## Test plan
- [ ] Launch nvim and confirm mouse clicks no longer move the cursor or select text in any mode (normal/insert/visual/command).
- [ ] Confirm tabline (bufferline) clicks are no longer captured by nvim — this is the intentional trade-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)