### PR TITLE
feat(keymap): single-stroke tab navigation

### DIFF
--- a/.config/nvim/lua/common/keymap.lua
+++ b/.config/nvim/lua/common/keymap.lua
@@ -14,3 +14,19 @@ vim.keymap.set("n", "<Esc><Esc>", ":noh<CR>", { noremap = true, silent = true, d
 
 -- Terminal escape
 vim.keymap.set("t", "<Esc>", "<c-\\><c-n>", { noremap = true, silent = true, desc = "Exit terminal mode" })
+
+-- Tab navigation: each tab roughly maps to a worktree in this config, so
+-- `gt`/`gT` gets tedious. Override H/L (screen top/bottom) with single-stroke
+-- tab cycling, and bind <Leader>1..9 / <Leader>0 to jump directly by index
+-- (matches the order shown in bufferline's tab bar).
+vim.keymap.set("n", "<S-l>", ":tabnext<CR>", { noremap = true, silent = true, desc = "Tab: next" })
+vim.keymap.set("n", "<S-h>", ":tabprevious<CR>", { noremap = true, silent = true, desc = "Tab: previous" })
+vim.keymap.set("n", "<Leader>0", ":tablast<CR>", { noremap = true, silent = true, desc = "Tab: last" })
+for i = 1, 9 do
+	vim.keymap.set(
+		"n",
+		"<Leader>" .. i,
+		string.format("<Cmd>tabnext %d<CR>", i),
+		{ noremap = true, silent = true, desc = "Tab: go to " .. i }
+	)
+end


### PR DESCRIPTION
## Summary
- `gt`/`gT` は 2 ストロークで、worktree-per-tab 運用だと頻度が高く疲れる
- `<S-l>` / `<S-h>` を tabnext / tabprevious に割り当て (H/L 画面移動は犠牲)
- `<Leader>1`〜`9` / `<Leader>0` で tab に直接ジャンプ (bufferline の表示順と一致)

## Test plan
- [ ] `nvim` 起動 → tab を 2 つ以上開き、`<S-l>` / `<S-h>` で next/prev に移動できること
- [ ] `<Leader>3` で 3 番目の tab にジャンプできること
- [ ] `<Leader>0` で最後の tab に移動できること
- [ ] tab が 1 つしか無い時に `<S-l>` 等を叩いてもエラーにならないこと
- [ ] 既存の `<leader>h` (quickhl), `<leader>tn` (test) 等と衝突しないこと