### PR TITLE
feat(claude): show idle marker on the worktree tab

### DIFF
--- a/.config/nvim/lua/plugins/configs/claude_notification.lua
+++ b/.config/nvim/lua/plugins/configs/claude_notification.lua
@@ -1,0 +1,116 @@
+-- Per-cwd "needs attention" flag for the claude :terminal in that cwd.
+-- Bufferline's name_formatter calls `pending(cwd)` and prepends a marker
+-- to the matching tab, so the user can see which worktree's claude has
+-- gone idle while they were elsewhere.
+
+local M = {}
+
+-- cwd -> { pending = bool, timer = uv_timer, buf = number }
+local state = {}
+
+-- Output is considered "settled" after this many ms of silence — that's when
+-- we decide claude has stopped streaming and the user might want to look.
+local IDLE_MS = 1500
+
+local augroup = vim.api.nvim_create_augroup("ClaudeNotification", { clear = true })
+
+local function buf_visible_in_current_tab(buf)
+	for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+		if vim.api.nvim_win_get_buf(win) == buf then
+			return true
+		end
+	end
+	return false
+end
+
+local function set_pending(cwd, val)
+	local entry = state[cwd]
+	if not entry then
+		return
+	end
+	if entry.pending == val then
+		return
+	end
+	entry.pending = val
+	vim.schedule(function()
+		pcall(vim.cmd, "redrawtabline")
+	end)
+end
+
+function M.pending(cwd)
+	local entry = state[cwd]
+	return entry and entry.pending or false
+end
+
+function M.clear(cwd)
+	set_pending(cwd, false)
+end
+
+local function close_timer(entry)
+	if entry and entry.timer then
+		entry.timer:stop()
+		entry.timer:close()
+		entry.timer = nil
+	end
+end
+
+function M.watch(buf, cwd)
+	-- Wipe any prior watcher for this cwd (reuse can happen if a buffer dies
+	-- and gets recreated under the same cwd key).
+	close_timer(state[cwd])
+
+	local entry = { pending = false, buf = buf, timer = vim.loop.new_timer() }
+	state[cwd] = entry
+
+	vim.api.nvim_buf_attach(buf, false, {
+		on_lines = function()
+			if not entry.timer then
+				return
+			end
+			entry.timer:stop()
+			entry.timer:start(
+				IDLE_MS,
+				0,
+				vim.schedule_wrap(function()
+					if not vim.api.nvim_buf_is_valid(buf) then
+						return
+					end
+					if buf_visible_in_current_tab(buf) then
+						return
+					end
+					set_pending(cwd, true)
+				end)
+			)
+		end,
+		on_detach = function()
+			close_timer(entry)
+			state[cwd] = nil
+			vim.schedule(function()
+				pcall(vim.cmd, "redrawtabline")
+			end)
+		end,
+	})
+
+	vim.api.nvim_create_autocmd("BufEnter", {
+		group = augroup,
+		buffer = buf,
+		callback = function()
+			set_pending(cwd, false)
+		end,
+	})
+end
+
+-- A single TabEnter handler clears pending for any claude buffer that becomes
+-- visible in the newly-entered tab — avoids creating one autocmd per buffer.
+vim.api.nvim_create_autocmd("TabEnter", {
+	group = augroup,
+	callback = function()
+		for cwd, entry in pairs(state) do
+			if entry.buf and vim.api.nvim_buf_is_valid(entry.buf) and buf_visible_in_current_tab(entry.buf) then
+				set_pending(cwd, false)
+			end
+		end
+	end,
+})
+
+return M

--- a/.config/nvim/lua/plugins/configs/claude_term.lua
+++ b/.config/nvim/lua/plugins/configs/claude_term.lua
@@ -107,6 +107,8 @@ function M.open(opts)
 	pcall(vim.api.nvim_buf_set_name, buf, "claude://" .. cwd)
 	terms[cwd] = { buf = buf, job_id = job_id }
 
+	require("plugins.configs.claude_notification").watch(buf, cwd)
+
 	vim.api.nvim_create_autocmd("BufWipeout", {
 		buffer = buf,
 		once = true,

--- a/.config/nvim/lua/plugins/ui.lua
+++ b/.config/nvim/lua/plugins/ui.lua
@@ -159,6 +159,10 @@ return {
 						if ok then
 							local label = vim.fn.fnamemodify(cwd, ":t")
 							if label ~= "" then
+								local ok_notif, notif = pcall(require, "plugins.configs.claude_notification")
+								if ok_notif and notif.pending(cwd) then
+									label = "● " .. label
+								end
 								return label
 							end
 						end


### PR DESCRIPTION
## Summary
- Watch each per-cwd claude `:terminal` for 1.5 s of output silence and flip a `pending` flag if the buffer isn't visible in the current tab.
- Bufferline `name_formatter` prefixes that tab's label with `● ` so you can see which worktree's claude went idle while you were elsewhere.
- `pending` clears on `BufEnter` into the claude buffer and on `TabEnter` into any tab where it is visible (single global autocmd, not one per session).

## Test plan
- [ ] Open claude in one worktree tab, switch away, send a prompt, wait for it to finish — the other tab's label gains `● `.
- [ ] Switch back to that tab; the `● ` disappears.
- [ ] Open claude in two worktree tabs; idle markers appear independently on each tab.
- [ ] Kill (`<leader>cx`) the claude buffer; the marker disappears and no stale state remains.
- [ ] Close a tab while the marker is showing on another; no E5108 / stack trace.