### PR TITLE
fix(telescope): restore default select action in pick_buffers

### DIFF
--- a/.config/nvim/lua/plugins/configs/telescope.lua
+++ b/.config/nvim/lua/plugins/configs/telescope.lua
@@ -44,8 +44,6 @@ local function pick_buffers(opts)
 	local finders = require("telescope.finders")
 	local conf = require("telescope.config").values
 	local make_entry = require("telescope.make_entry")
-	local actions = require("telescope.actions")
-	local action_state = require("telescope.actions.state")
 
 	local terminal_only = opts.terminal_only
 	local cwd = tab_cwd()
@@ -96,16 +94,6 @@ local function pick_buffers(opts)
 			}),
 			sorter = conf.generic_sorter(opts),
 			previewer = conf.grep_previewer(opts),
-			attach_mappings = function(prompt_bufnr, _)
-				actions.select_default:replace(function()
-					local entry = action_state.get_selected_entry()
-					actions.close(prompt_bufnr)
-					if entry and entry.bufnr and vim.api.nvim_buf_is_valid(entry.bufnr) then
-						vim.api.nvim_set_current_buf(entry.bufnr)
-					end
-				end)
-				return true
-			end,
 		})
 		:find()
 end


### PR DESCRIPTION
## Summary
- `pick_buffers()` の `attach_mappings` で `actions.select_default` を `vim.api.nvim_set_current_buf` に置き換えていたが、これだと telescope 既定の `:buffer N` 経由ルート（jumplist や BufLeave/BufEnter の挙動）から外れていた
- カスタム select を削除し、telescope デフォルトの選択アクションに委任
- worktree スコープ (`tab_cwd` + `buf_under`) と terminal buffer 判別は維持

## Test plan
- [x] \`bash tests/run.sh\` (luac + stylua + worktree_prompt) pass
- [x] headless nvim で \`require(\"plugins.configs.telescope\")\` 読み込み OK / \`;\` キーマップが \`pick_buffers\` を指すことを確認
- [ ] 実機で \`;\` から buffer を選択し、jumplist (\`<C-o>\` で戻れる) と通常の \`:buffer N\` と同等の autocmd 発火を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)