### PR TITLE
Scope `;` to the current tab's cwd buffers

### DIFF
--- a/.config/nvim/lua/plugins/configs/telescope.lua
+++ b/.config/nvim/lua/plugins/configs/telescope.lua
@@ -22,6 +22,17 @@ local function pick_terminal_buffers(opts)
 		return vim.fn.getbufinfo(a)[1].lastused > vim.fn.getbufinfo(b)[1].lastused
 	end)
 
+	-- gen_from_buffer reads opts.bufnr_width to align the bufnr column;
+	-- telescope.builtin.buffers precomputes it, so a standalone picker must too
+	-- or the finder dies with "bufnr_width (a nil value)".
+	if not opts.bufnr_width then
+		local max_bufnr = 0
+		for _, b in ipairs(bufnrs) do
+			max_bufnr = math.max(max_bufnr, b)
+		end
+		opts.bufnr_width = #tostring(max_bufnr)
+	end
+
 	local current = vim.api.nvim_get_current_buf()
 	local alternate = vim.fn.bufnr("#")
 	local buffers = {}
@@ -144,12 +155,12 @@ return function()
 		"<cmd>lua Snacks.picker.grep({ hidden = true })<CR>",
 		{ noremap = true, silent = false }
 	)
-	vim.keymap.set(
-		"n",
-		";",
-		"<cmd>Telescope buffers<CR>",
-		{ noremap = true, silent = false, desc = "Telescope: buffers" }
-	)
+	-- `;` lists only the current tab's buffers. Each tab is :tcd-pinned to its
+	-- worktree, so cwd_only (filtered against the tab's effective cwd) scopes
+	-- the list per worktree using telescope's builtin — no custom state.
+	vim.keymap.set("n", ";", function()
+		require("telescope.builtin").buffers({ cwd_only = true, sort_mru = true })
+	end, { noremap = true, silent = true, desc = "Buffers in current tab cwd" })
 	vim.api.nvim_create_user_command("TelescopeTerminals", function()
 		pick_terminal_buffers()
 	end, { desc = "Telescope picker over terminal buffers only" })

--- a/tests/tab_buffers.sh
+++ b/tests/tab_buffers.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# `;` lists only the current tab's buffers via telescope's builtin
+# (cwd_only). Each tab is :tcd-pinned to a worktree, so this scopes the buffer
+# list per worktree without custom state. Guard the keymap rebind so it can't
+# silently revert to the global buffer list (the old `<cmd>Telescope buffers`).
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+run_nv \
+  -c 'lua local d = vim.fn.maparg(";", "n", false, true); if not (type(d) == "table" and d.callback) then print("; not mapped to a callback"); vim.cmd("cquit") end; if d.desc ~= "Buffers in current tab cwd" then print("unexpected ; desc: " .. tostring(d.desc)); vim.cmd("cquit") end' \
+  -c qa


### PR DESCRIPTION
## What
`;` で開く buffer 一覧を、現在のタブ (≒ worktree) の buffer だけに絞る。

各タブは `:tcd` でその worktree ディレクトリに固定されているため、telescope
標準の `cwd_only` がそのままタブ単位の絞り込みになる。カスタム状態は持たない。

- `;` : `<cmd>Telescope buffers<CR>` (全 buffer) →
  `telescope.builtin.buffers({ cwd_only = true, sort_mru = true })`
- ついでに terminal picker (`pick_terminal_buffers`) の潜在バグ修正:
  `gen_from_buffer` が要求する `opts.bufnr_width` を未設定だと
  `bufnr_width (a nil value)` で Finder が落ちるため、builtin と同様に事前計算。

## cwd_only の割り切り
パスベースの絞り込みなので、worktree 外のファイルは出ず、同一 cwd の複数タブは
区別しない。worktree 運用ではタブ＝別ディレクトリなので実用上十分。

## Test
- `bash tests/run.sh` 全 pass。
- `tests/tab_buffers.sh`: `;` が callback にマップされ desc が
  "Buffers in current tab cwd" であること (= 全 buffer へ戻っていない) を担保。
- 手動: tcd 配下で `;`、terminal で `:TelescopeTerminals` がエラー無し。

🤖 Generated with [Claude Code](https://claude.com/claude-code)