### PR TITLE
feat(ui): add tab numbers to the bufferline tab bar

### DIFF
--- a/.config/nvim/lua/plugins/ui.lua
+++ b/.config/nvim/lua/plugins/ui.lua
@@ -147,6 +147,10 @@ return {
 			options = {
 				mode = "tabs",
 				style_preset = "default",
+				-- Prefix each tab with its ordinal (1., 2., …) so it doubles as
+				-- the `<n>gt` target. In tabs mode the ordinal equals the tab's
+				-- position, i.e. the number Vim uses for `:tabnext`.
+				numbers = "ordinal",
 				diagnostics = "nvim_lsp",
 				show_buffer_close_icons = false,
 				show_close_icon = false,

--- a/tests/tab_numbers.sh
+++ b/tests/tab_numbers.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# The tab page bar prefixes each tab with its ordinal number (issue #42).
+# bufferline renders this from `options.numbers = "ordinal"`; in tabs mode the
+# ordinal equals the tab position (the `<n>gt` target). Guard both the resolved
+# option and the rendered tabline so a future opts edit can't silently drop it.
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+# 1. Resolved bufferline config keeps numbers = "ordinal".
+run_nv \
+  -c 'lua require("lazy").load({ plugins = { "bufferline.nvim" } })' \
+  -c 'lua local n = require("bufferline.config").options.numbers; if n ~= "ordinal" then print("bufferline numbers is " .. tostring(n) .. ", expected ordinal"); vim.cmd("cquit") end' \
+  -c qa
+
+# 2. The rendered tabline actually shows ordinals for each open tab.
+run_nv \
+  -c 'lua vim.cmd("edit /tmp/nvim_tab_a"); vim.cmd("tabnew /tmp/nvim_tab_b"); vim.cmd("tabnew /tmp/nvim_tab_c")' \
+  -c 'lua require("lazy").load({ plugins = { "bufferline.nvim" } })' \
+  -c 'lua vim.api.nvim_exec_autocmds("User", { pattern = "VeryLazy" })' \
+  -c 'lua vim.schedule(function()
+        local rendered = vim.api.nvim_eval_statusline(vim.o.tabline, { use_tabline = true }).str
+        for _, n in ipairs({ "1.", "2.", "3." }) do
+          if not rendered:find(n, 1, true) then
+            print("tabline missing ordinal " .. n .. ", got: " .. rendered)
+            vim.cmd("cquit")
+          end
+        end
+        vim.cmd("qa")
+      end)'


### PR DESCRIPTION
Set bufferline's numbers = "ordinal" so each tab is prefixed with its
number (1., 2., …). In tabs mode the ordinal equals the tab position,
i.e. the number Vim uses for <n>gt / :tabnext.

Add tests/tab_numbers.sh covering the resolved option and the rendered
tabline. Closes #42.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
