### PR TITLE
refactor(completion): migrate nvim-cmp → blink.cmp

### DIFF
--- a/.config/nvim/lua/plugins/completion.lua
+++ b/.config/nvim/lua/plugins/completion.lua
@@ -1,58 +1,61 @@
 return {
 	{
-		"hrsh7th/nvim-cmp",
+		"saghen/blink.cmp",
 		event = "InsertEnter",
-		dependencies = {
-			"hrsh7th/cmp-buffer",
-			"hrsh7th/cmp-path",
-			"hrsh7th/cmp-nvim-lsp",
-			"rafamadriz/friendly-snippets",
-		},
-		config = function()
-			local cmp = require("cmp")
-
-			cmp.setup({
-				mapping = cmp.mapping.preset.insert({
-					["<C-k>"] = cmp.mapping.select_prev_item(),
-					["<C-j>"] = cmp.mapping.select_next_item(),
-					["<C-b>"] = cmp.mapping.scroll_docs(-4),
-					["<C-f>"] = cmp.mapping.scroll_docs(4),
-					["<C-Space>"] = cmp.mapping.complete(),
-					["<C-e>"] = cmp.mapping.abort(),
-					["<CR>"] = cmp.mapping.confirm({ select = true }),
-				}),
-				sources = cmp.config.sources({
-					{ name = "nvim_lsp", priority = 900 },
-					{ name = "path", priority = 700 },
-				}, {
-					{
-						name = "buffer",
-						priority = 600,
-						option = {
+		-- A versioned tag pulls the prebuilt Rust fuzzy matcher from the release
+		-- instead of requiring a local `cargo build`.
+		version = "1.*",
+		dependencies = { "rafamadriz/friendly-snippets" },
+		opts = {
+			-- Keep the muscle memory from the old nvim-cmp setup: <C-j>/<C-k>
+			-- cycle items and <CR> confirms. Everything else (<C-n>/<C-p>,
+			-- <C-b>/<C-f> doc scroll, <C-Space> show, <C-e> hide) comes from
+			-- blink's "default" preset, so we only override what differs.
+			keymap = {
+				preset = "default",
+				["<C-j>"] = { "select_next", "fallback" },
+				["<C-k>"] = { "select_prev", "fallback" },
+				["<CR>"] = { "accept", "fallback" },
+			},
+			appearance = {
+				nerd_font_variant = "mono",
+			},
+			completion = {
+				documentation = { auto_show = true },
+				menu = {
+					draw = {
+						-- Mirror the old [LSP]/[Path]/[Buffer] menu labels via the
+						-- provider `name`s set below.
+						columns = {
+							{ "kind_icon", "label", gap = 1 },
+							{ "source_name" },
+						},
+					},
+				},
+			},
+			-- blink's default source list is already { lsp, path, snippets,
+			-- buffer }, so we leave sources.default untouched and only relabel
+			-- the providers ([LSP]/[Path]/…) and widen the buffer source.
+			sources = {
+				providers = {
+					lsp = { name = "[LSP]" },
+					path = { name = "[Path]" },
+					snippets = { name = "[Snippet]" },
+					buffer = {
+						name = "[Buffer]",
+						-- The old config completed across every loaded buffer, not
+						-- just the visible ones; keep that wider reach.
+						opts = {
 							get_bufnrs = function()
-								local bufs = {}
-								for _, buf in ipairs(vim.api.nvim_list_bufs()) do
-									if vim.api.nvim_buf_is_loaded(buf) then
-										table.insert(bufs, buf)
-									end
-								end
-								return bufs
+								return vim.tbl_filter(function(bufnr)
+									return vim.api.nvim_buf_is_loaded(bufnr)
+								end, vim.api.nvim_list_bufs())
 							end,
 						},
 					},
-				}),
-				formatting = {
-					format = function(entry, vim_item)
-						vim_item.menu = ({
-							nvim_lsp = "[LSP]",
-							buffer = "[Buffer]",
-							path = "[Path]",
-						})[entry.source.name]
-						return vim_item
-					end,
 				},
-			})
-		end,
+			},
+		},
 	},
 	{
 		"windwp/nvim-autopairs",

--- a/.config/nvim/lua/plugins/configs/lspconfig.lua
+++ b/.config/nvim/lua/plugins/configs/lspconfig.lua
@@ -1,7 +1,11 @@
 return function()
 	require("fidget").setup({})
 
-	local capabilities = require("cmp_nvim_lsp").default_capabilities()
+	-- Completion capabilities now come from blink.cmp (was cmp_nvim_lsp). Fall
+	-- back to plain client capabilities if blink isn't loaded yet so LspAttach
+	-- never errors.
+	local ok, blink = pcall(require, "blink.cmp")
+	local capabilities = ok and blink.get_lsp_capabilities() or vim.lsp.protocol.make_client_capabilities()
 
 	-- 全サーバー共通の設定
 	vim.lsp.config("*", {

--- a/tests/blink_cmp.sh
+++ b/tests/blink_cmp.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Regression: completion runs on blink.cmp (migrated off nvim-cmp), and LSP
+# capabilities are sourced from blink.cmp.get_lsp_capabilities() instead of
+# cmp_nvim_lsp. Guards both the spec (static greps) and runtime behavior.
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+COMPLETION="$REPO_ROOT/.config/nvim/lua/plugins/completion.lua"
+LSPCONFIG="$REPO_ROOT/.config/nvim/lua/plugins/configs/lspconfig.lua"
+
+# --- static guards -----------------------------------------------------------
+grep -q 'saghen/blink.cmp' "$COMPLETION" \
+  || { echo "completion.lua no longer references blink.cmp" >&2; exit 1; }
+if grep -qE 'hrsh7th/nvim-cmp|require\("cmp"\)' "$COMPLETION"; then
+  echo "completion.lua still references nvim-cmp" >&2; exit 1
+fi
+grep -q 'blink.cmp' "$LSPCONFIG" && grep -q 'get_lsp_capabilities' "$LSPCONFIG" \
+  || { echo "lspconfig.lua does not source capabilities from blink.cmp" >&2; exit 1; }
+if grep -qE 'require\([^)]*cmp_nvim_lsp' "$LSPCONFIG"; then
+  echo "lspconfig.lua still requires cmp_nvim_lsp" >&2; exit 1
+fi
+
+# --- headless behavior -------------------------------------------------------
+# Requiring blink.cmp force-loads the lazy plugin (it is event = InsertEnter),
+# which runs setup() and populates blink.cmp.config from our opts. Kept on one
+# physical line: backslash-newline is literal inside single quotes, so a
+# multi-line chunk would reach nvim with stray '\'.
+run_nv -c 'lua local ok, blink = pcall(require, "blink.cmp"); if not ok then print("blink.cmp failed to load: " .. tostring(blink)); vim.cmd("cquit") end; local caps = blink.get_lsp_capabilities(); if type(caps) ~= "table" or not (caps.textDocument and caps.textDocument.completion) then print("get_lsp_capabilities missing completion capability"); vim.cmd("cquit") end; local cfg = require("blink.cmp.config"); for _, lhs in ipairs({ "<C-j>", "<C-k>", "<CR>" }) do if cfg.keymap[lhs] == nil then print("blink keymap missing: " .. lhs); vim.cmd("cquit") end end; if cfg.sources.providers.lsp.name ~= "[LSP]" or cfg.sources.providers.buffer.name ~= "[Buffer]" then print("blink provider labels not preserved"); vim.cmd("cquit") end; if pcall(require, "cmp") then print("nvim-cmp (require cmp) is still loadable"); vim.cmd("cquit") end' -c qa


### PR DESCRIPTION
Swap the completion engine to blink.cmp (versioned tag for the prebuilt
Rust matcher) while preserving the existing UX:

- keymaps <C-j>/<C-k>/<CR> kept on top of blink's "default" preset
- [LSP]/[Path]/[Snippet]/[Buffer] menu labels via provider names
- buffer source still completes across all loaded buffers (get_bufnrs)
- friendly-snippets retained; snippets now actually surface in the menu

LSP capabilities now come from blink.cmp.get_lsp_capabilities() (was
cmp_nvim_lsp), with a fallback to plain client capabilities so LspAttach
never errors if blink hasn't loaded yet.

Adds tests/blink_cmp.sh guarding the spec (blink in, nvim-cmp out) and
runtime (blink loads, capabilities + keymaps + provider labels resolve,
`require("cmp")` no longer loadable).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
