### PR TITLE
refactor(picker): finish telescope → snacks.picker migration

### DIFF
--- a/.config/nvim/lua/plugins/configs/pickers.lua
+++ b/.config/nvim/lua/plugins/configs/pickers.lua
@@ -1,0 +1,88 @@
+-- Snacks-based pickers, registered at startup.
+--
+-- The file/grep pickers and the `;` / terminal buffer pickers all run on
+-- Snacks.picker now; telescope is left with only the worktree pickers
+-- (plugins.configs.worktree) and the git_worktree / server extensions and so
+-- loads lazily. These keymaps must be bound at startup, which is why they live
+-- here rather than in telescope's (now lazy) config. Snacks is `lazy = false`,
+-- so `Snacks.picker.*` is always available by the time a key is pressed.
+local tab_buffers = require("plugins.configs.tab_buffers")
+
+local M = {}
+
+-- Snacks.picker.buffers has no per-tab or terminal scoping, so we hand it an
+-- explicit allowlist of bufnrs through its `filter.filter` predicate. The
+-- buffers finder applies the predicate to every candidate, so only allowlisted
+-- buffers survive. `hidden = true` keeps the allowlist (not buflisted-ness) the
+-- sole authority over what shows.
+local function pick_allowed(wanted, opts)
+	return Snacks.picker.buffers(vim.tbl_extend("force", {
+		hidden = true,
+		sort_lastused = true,
+		filter = {
+			filter = function(item)
+				return wanted[item.buf] == true
+			end,
+		},
+	}, opts or {}))
+end
+
+-- Picker scoped to the current tab's buffers (see plugins.configs.tab_buffers).
+function M.pick_tab_buffers()
+	local wanted = {}
+	for _, b in ipairs(tab_buffers.current_tab_bufnrs()) do
+		wanted[b] = true
+	end
+	if not next(wanted) then
+		vim.notify("No buffers in this tab", vim.log.levels.INFO)
+		return
+	end
+	pick_allowed(wanted, { title = "Buffers (this tab)" })
+end
+
+-- Picker scoped to terminal buffers only.
+function M.pick_terminal_buffers()
+	local wanted = {}
+	for _, b in ipairs(vim.api.nvim_list_bufs()) do
+		if vim.api.nvim_buf_is_valid(b) and vim.bo[b].buftype == "terminal" then
+			wanted[b] = true
+		end
+	end
+	if not next(wanted) then
+		vim.notify("No terminal buffers", vim.log.levels.INFO)
+		return
+	end
+	pick_allowed(wanted, { title = "Terminal Buffers", nofile = true })
+end
+
+-- Register the Snacks-backed pickers + per-tab buffer tracking. Idempotent.
+function M.setup()
+	-- Track per-tab buffer membership so `;` can scope to the current tab.
+	tab_buffers.setup()
+
+	vim.keymap.set("n", "<Leader>ff", function()
+		Snacks.picker.git_files()
+	end, { noremap = true, silent = true, desc = "Find git files" })
+	vim.keymap.set("n", "<Leader>fg", function()
+		Snacks.picker.grep({ hidden = true })
+	end, { noremap = true, silent = true, desc = "Live grep" })
+
+	-- `;` lists only the current tab's buffers (own per-tab tracking, not
+	-- telescope's path-based cwd_only) so worktree tabs don't bleed into each
+	-- other even when they share a cwd.
+	vim.keymap.set("n", ";", M.pick_tab_buffers, {
+		noremap = true,
+		silent = true,
+		desc = "Buffers in current tab",
+	})
+	vim.keymap.set("n", "<Leader>;", M.pick_terminal_buffers, {
+		noremap = true,
+		silent = true,
+		desc = "Terminal buffers (Snacks)",
+	})
+	vim.api.nvim_create_user_command("TerminalBuffers", M.pick_terminal_buffers, {
+		desc = "Snacks picker over terminal buffers only",
+	})
+end
+
+return M

--- a/.config/nvim/lua/plugins/configs/telescope.lua
+++ b/.config/nvim/lua/plugins/configs/telescope.lua
@@ -1,85 +1,11 @@
-local tab_buffers = require("plugins.configs.tab_buffers")
-
--- Open a telescope buffer picker over an explicit bufnr list. Mirrors
--- telescope.builtin.buffers, which has no per-tab or terminal filter, so callers
--- decide exactly which buffers to show.
-local function pick_buffers(bufnrs, opts)
-	opts = opts or {}
-	local pickers = require("telescope.pickers")
-	local finders = require("telescope.finders")
-	local conf = require("telescope.config").values
-	local make_entry = require("telescope.make_entry")
-
-	table.sort(bufnrs, function(a, b)
-		return vim.fn.getbufinfo(a)[1].lastused > vim.fn.getbufinfo(b)[1].lastused
-	end)
-
-	-- gen_from_buffer reads opts.bufnr_width to align the bufnr column;
-	-- telescope.builtin.buffers precomputes it, so a standalone picker must too
-	-- or the finder dies with "bufnr_width (a nil value)".
-	if not opts.bufnr_width then
-		local max_bufnr = 0
-		for _, b in ipairs(bufnrs) do
-			max_bufnr = math.max(max_bufnr, b)
-		end
-		opts.bufnr_width = #tostring(max_bufnr)
-	end
-
-	local current = vim.api.nvim_get_current_buf()
-	local alternate = vim.fn.bufnr("#")
-	local buffers = {}
-	for _, bufnr in ipairs(bufnrs) do
-		local flag = bufnr == current and "%" or (bufnr == alternate and "#" or " ")
-		table.insert(buffers, {
-			bufnr = bufnr,
-			flag = flag,
-			info = vim.fn.getbufinfo(bufnr)[1],
-		})
-	end
-
-	pickers
-		.new(opts, {
-			prompt_title = opts.prompt_title or "Buffers",
-			finder = finders.new_table({
-				results = buffers,
-				entry_maker = opts.entry_maker or make_entry.gen_from_buffer(opts),
-			}),
-			sorter = conf.generic_sorter(opts),
-			previewer = conf.grep_previewer(opts),
-		})
-		:find()
-end
-
--- Picker scoped to terminal buffers only, since telescope has no native
--- terminal filter.
-local function pick_terminal_buffers(opts)
-	opts = opts or {}
-	local bufnrs = {}
-	for _, b in ipairs(vim.api.nvim_list_bufs()) do
-		if vim.api.nvim_buf_is_valid(b) and vim.bo[b].buftype == "terminal" then
-			table.insert(bufnrs, b)
-		end
-	end
-	if not next(bufnrs) then
-		vim.notify("No terminal buffers", vim.log.levels.INFO)
-		return
-	end
-	opts.prompt_title = opts.prompt_title or "🖥  Terminal Buffers"
-	pick_buffers(bufnrs, opts)
-end
-
--- Picker scoped to the current tab's buffers (see plugins.configs.tab_buffers).
-local function pick_tab_buffers(opts)
-	opts = opts or {}
-	local bufnrs = tab_buffers.current_tab_bufnrs()
-	if not next(bufnrs) then
-		vim.notify("No buffers in this tab", vim.log.levels.INFO)
-		return
-	end
-	opts.prompt_title = opts.prompt_title or "✨ Buffers (this tab) ✨"
-	pick_buffers(bufnrs, opts)
-end
-
+-- Telescope config.
+--
+-- Post Snacks migration telescope only backs the worktree pickers
+-- (plugins.configs.worktree) and the git_worktree / server extensions, both of
+-- which are telescope-specific extensions shipped by external plugins and have
+-- no Snacks equivalent. File/grep/buffer pickers moved to Snacks
+-- (plugins.configs.pickers), so telescope loads lazily (cmd/keys) and this
+-- config runs the first time it is needed.
 return function()
 	local actions = require("telescope.actions")
 	local mappings = {
@@ -97,11 +23,7 @@ return function()
 			["<c-d>"] = actions.preview_scrolling_down,
 		},
 	}
-	-- Track per-tab buffer membership so `;` can scope to the current tab.
-	tab_buffers.setup()
 
-	-- Global remapping
-	------------------------------
 	require("telescope").setup({
 		defaults = {
 			-- please install fzy
@@ -109,97 +31,11 @@ return function()
 			generic_sorter = require("telescope.sorters").get_fzy_sorter,
 			mappings = mappings,
 		},
-		pickers = {
-			-- Your special builtin config goes in here
-			buffers = {
-				prompt_title = "✨ Search Buffers ✨",
-				mappings = mappings,
-				sort_mru = true,
-				preview_title = false,
-				-- theme = "ivy",
-			},
-			git_files = {
-				mappings = mappings,
-				sort_mru = true,
-				preview_title = false,
-				prompt_title = "",
-				prompt_prefix = "     ",
-				selection_caret = "  ",
-				entry_prefix = "  ",
-				sorting_strategy = "ascending",
-				layout_strategy = "horizontal",
-				layout_config = {
-					horizontal = {
-						prompt_position = "top",
-						preview_width = 0.55,
-						results_width = 0.8,
-					},
-					vertical = {
-						mirror = false,
-					},
-					width = 0.80,
-					height = 0.85,
-					preview_cutoff = 120,
-				},
-				winblend = 0,
-				set_env = { ["COLORTERM"] = "truecolor" },
-				selection_strategy = "reset",
-				results_title = "",
-				color_devicons = true,
-				use_less = true,
-				-- ignore rbi
-				file_ignore_patterns = { "%.rbi" },
-			},
-			grep_string = {
-				mappings = mappings,
-				file_ignore_patterns = { "%.rbi" },
-			},
-			live_grep = {
-				additional_args = function()
-					return { "--hidden" }
-				end,
-				file_ignore_patterns = { "%.rbi" },
-			},
-			registers = {
-				mappings = mappings,
-				-- theme="ivy",
-			},
-			git_bcommits = {
-				mappings = mappings,
-				theme = "ivy",
-			},
-		},
 	})
 
-	-- vim.keymap.set("n", "<Leader>ff", "<cmd>Telescope git_files<CR>", { noremap = true, silent = false })
-	vim.keymap.set("n", "<Leader>ff", "<cmd>lua Snacks.picker.git_files()<CR>", { noremap = true, silent = false })
-	-- vim.keymap.set("n", "<Leader>fg", "<cmd>Telescope live_grep<CR>", { noremap = true, silent = false })
-	vim.keymap.set(
-		"n",
-		"<Leader>fg",
-		"<cmd>lua Snacks.picker.grep({ hidden = true })<CR>",
-		{ noremap = true, silent = false }
-	)
-	-- `;` lists only the current tab's buffers (own implementation, not
-	-- telescope's path-based cwd_only) so worktree tabs don't bleed into each
-	-- other even when they share a cwd.
-	vim.keymap.set("n", ";", function()
-		pick_tab_buffers()
-	end, { noremap = true, silent = true, desc = "Buffers in current tab" })
-	vim.api.nvim_create_user_command("TelescopeTerminals", function()
-		pick_terminal_buffers()
-	end, { desc = "Telescope picker over terminal buffers only" })
-	vim.keymap.set("n", "<Leader>;", function()
-		pick_terminal_buffers()
-	end, { noremap = true, silent = true, desc = "Telescope: terminal buffers" })
-	-- vim.keymap.set(
-	-- 	"n",
-	-- 	";",
-	-- 	"<cmd>lua Snacks.picker.buffers({ hidden = true })<CR>",
-	-- 	{ noremap = true, silent = false }
-	-- )
-
-	-- load telescope extensions
+	-- Telescope-only extensions (no Snacks equivalent). Requiring the extension
+	-- triggers lazy.nvim to load the providing plugin, so this works even though
+	-- both are lazy.
 	require("telescope").load_extension("git_worktree")
 	require("telescope").load_extension("server")
 end

--- a/.config/nvim/lua/plugins/editor.lua
+++ b/.config/nvim/lua/plugins/editor.lua
@@ -26,7 +26,10 @@ return {
 	},
 	{
 		"nvim-telescope/telescope.nvim",
-		lazy = false,
+		-- Lazy now: only the worktree pickers + git_worktree/server extensions
+		-- still use telescope. The worktree pickers `require` telescope modules
+		-- on demand and the extensions load via :Telescope, so there is no need
+		-- to load it at startup. File/grep/buffer pickers are on Snacks.
 		cmd = "Telescope",
 		keys = {
 			{ "<Leader>fs", "<cmd>Telescope server servers<CR>", desc = "Server list" },
@@ -39,6 +42,13 @@ return {
 		"folke/snacks.nvim",
 		priority = 1000,
 		lazy = false,
+		-- Snacks is loaded at startup, so the Snacks-backed pickers and the
+		-- per-tab buffer tracking they rely on are registered here (telescope is
+		-- lazy now and can no longer host these startup keymaps).
+		config = function(_, opts)
+			require("snacks").setup(opts)
+			require("plugins.configs.pickers").setup()
+		end,
 		opts = {
 			bufdelete = { enabled = true },
 			dashboard = { enabled = false },

--- a/tests/snacks_pickers.sh
+++ b/tests/snacks_pickers.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Telescope -> Snacks.picker migration (issue #49).
+#
+# The `;` (current-tab buffers) and `<Leader>;` / :TerminalBuffers (terminal
+# buffers) pickers run on Snacks.picker now, scoped by handing Snacks an
+# explicit bufnr allowlist via its `filter.filter` predicate. telescope keeps
+# only the worktree pickers + git_worktree/server extensions and loads lazily.
+# Guard the spec (static greps) and the runtime registration so the pickers
+# can't silently revert to telescope.
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+PICKERS="$REPO_ROOT/.config/nvim/lua/plugins/configs/pickers.lua"
+TELESCOPE="$REPO_ROOT/.config/nvim/lua/plugins/configs/telescope.lua"
+EDITOR="$REPO_ROOT/.config/nvim/lua/plugins/editor.lua"
+
+# --- static guards -----------------------------------------------------------
+# Snacks-backed pickers, scoped via the tab-buffer allowlist + Snacks filter.
+grep -q 'Snacks.picker.buffers' "$PICKERS" \
+	|| { echo "pickers.lua no longer uses Snacks.picker.buffers" >&2; exit 1; }
+grep -q 'current_tab_bufnrs' "$PICKERS" \
+	|| { echo "pickers.lua dropped the per-tab scoping (current_tab_bufnrs)" >&2; exit 1; }
+grep -q 'filter' "$PICKERS" \
+	|| { echo "pickers.lua dropped the Snacks filter (scoping is gone)" >&2; exit 1; }
+
+# The custom telescope buffer picker must be gone from telescope.lua.
+if grep -qE 'telescope\.(pickers|finders)|pick_buffers|pick_tab_buffers|pick_terminal_buffers' "$TELESCOPE"; then
+	echo "telescope.lua still hand-rolls a telescope buffer picker" >&2; exit 1
+fi
+# telescope is kept only for the extensions with no Snacks equivalent.
+grep -q 'load_extension("git_worktree")' "$TELESCOPE" \
+	&& grep -q 'load_extension("server")' "$TELESCOPE" \
+	|| { echo "telescope.lua no longer loads the git_worktree/server extensions" >&2; exit 1; }
+
+# telescope must be lazy now (no `lazy = false` on its spec). Scope the grep to
+# the telescope spec block so snacks' own `lazy = false` doesn't mask a regression.
+if awk '/"nvim-telescope\/telescope.nvim"/{f=1} f&&/lazy = false/{print; exit} /folke\/snacks.nvim/{f=0}' "$EDITOR" | grep -q 'lazy = false'; then
+	echo "telescope.nvim spec is still lazy = false (migration incomplete)" >&2; exit 1
+fi
+
+# --- headless behavior -------------------------------------------------------
+# Module API.
+run_nv -c 'lua local ok, m = pcall(require, "plugins.configs.pickers"); if not ok or type(m) ~= "table" then print("require pickers failed: " .. tostring(m)); vim.cmd("cquit") end; for _, n in ipairs({ "setup", "pick_tab_buffers", "pick_terminal_buffers" }) do if type(m[n]) ~= "function" then print("missing pickers API: " .. n); vim.cmd("cquit") end end' -c qa
+
+# Snacks (lazy = false) is up at startup and exposes the picker we delegate to,
+# so the keymap callbacks are not no-ops.
+run_nv -c 'lua if type(Snacks) ~= "table" or type(Snacks.picker) ~= "table" or type(Snacks.picker.buffers) ~= "function" then print("Snacks.picker.buffers unavailable at startup"); vim.cmd("cquit") end' -c qa
+
+# `;` is a callback (the Snacks tab picker), not the old `<cmd>Telescope ...`,
+# and keeps its desc so the rebind can't silently revert.
+run_nv -c 'lua local d = vim.fn.maparg(";", "n", false, true); if not (type(d) == "table" and d.callback) then print("; not mapped to a callback"); vim.cmd("cquit") end; if d.desc ~= "Buffers in current tab" then print("unexpected ; desc: " .. tostring(d.desc)); vim.cmd("cquit") end' -c qa
+
+# `<Leader>;` is the terminal-buffer picker callback.
+run_nv -c 'lua local d = vim.fn.maparg(" ;", "n", false, true); if not (type(d) == "table" and d.callback) then print("<Leader>; not mapped to a callback"); vim.cmd("cquit") end' -c qa
+
+# Command renamed off "Telescope": :TerminalBuffers exists, the old name is gone.
+run_nv -c 'lua if vim.fn.exists(":TerminalBuffers") ~= 2 then print("TerminalBuffers command not registered"); vim.cmd("cquit") end; if vim.fn.exists(":TelescopeTerminals") == 2 then print("stale TelescopeTerminals command still registered"); vim.cmd("cquit") end' -c qa
+
+# telescope is lazy: nothing at startup should have loaded it.
+run_nv -c 'lua if package.loaded["telescope"] ~= nil then print("telescope loaded at startup (should be lazy)"); vim.cmd("cquit") end' -c qa
+
+# Terminal picker degrades cleanly when there are no terminal buffers: it must
+# notify and return without opening a picker (so this is safe to call headless).
+run_nv -c 'lua local m = require("plugins.configs.pickers"); local ok, err = pcall(m.pick_terminal_buffers); if not ok then print("pick_terminal_buffers errored on empty case: " .. tostring(err)); vim.cmd("cquit") end' -c qa


### PR DESCRIPTION
Closes #49.

Completes the Telescope → Snacks.picker migration around `telescope.lua`.

## Changes
- **`pickers.lua` (new)** — `;` (current-tab buffers) and `<Leader>;` / `:TerminalBuffers` now run on `Snacks.picker.buffers`. Scoping is reproduced by handing Snacks an explicit bufnr allowlist via its `filter.filter` predicate: the tab list comes from `tab_buffers.current_tab_bufnrs()`, the terminal list from `buftype == "terminal"`. Startup keymaps (`<leader>ff`/`<leader>fg`/`;`/`<Leader>;`) and per-tab tracking (`tab_buffers.setup()`) live here, registered from the `lazy = false` Snacks config.
- **`telescope.lua`** — drops the hand-rolled telescope buffer picker (`pick_buffers`/`pick_tab_buffers`/`pick_terminal_buffers`) and all startup keymaps. Keeps only `telescope.setup()` defaults + the `git_worktree` / `server` extension loads.
- **`editor.lua`** — telescope is no longer `lazy = false`; it loads on demand (`cmd`/`keys`). Snacks gains a `config` that runs `pickers.setup()` after `snacks.setup()`.
- Renamed `:TelescopeTerminals` → `:TerminalBuffers` (no longer telescope-backed).

## Extension decision (issue checkbox 3)
`git_worktree` (`git_worktree.nvim`) and `server` (`server.nvim`) are both **telescope-specific extensions with no Snacks equivalent**, so they stay on telescope. telescope is kept but made lazy; the worktree pickers `require` telescope on demand and `load_extension` chain-loads the providing plugin via lazy.nvim's require hook.

## Verification
- `bash tests/run.sh` → exit 0. New `tests/snacks_pickers.sh` guards the migration (static greps + headless registration); existing `tests/tab_buffers.sh` scope premise still holds.
- Headless end-to-end checks: Snacks `filter.filter` + buffers source scopes to the allowlist (allowed buf in, disallowed out); telescope is unloaded at startup and, when loaded on demand, runs its config and registers both extensions with `:Telescope` available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)