### PR TITLE
fix(nvim): modernize deprecated vim APIs for 0.12-dev

### DIFF
--- a/.config/nvim/lua/config/autocmds.lua
+++ b/.config/nvim/lua/config/autocmds.lua
@@ -7,7 +7,10 @@ vim.api.nvim_create_autocmd({ "BufWritePre" }, {
 -- yank highlight
 vim.api.nvim_create_autocmd({ "TextYankPost" }, {
 	pattern = { "*" },
-	command = "silent! lua vim.highlight.on_yank{higroup='IncSearch', timeout=700}",
+	callback = function()
+		-- on_yank moved to the vim.hl namespace in 0.11; fall back for older nvim.
+		pcall((vim.hl or vim.highlight).on_yank, { higroup = "IncSearch", timeout = 700 })
+	end,
 })
 
 -- restore cursor shape

--- a/.config/nvim/lua/plugins/configs/lualine.lua
+++ b/.config/nvim/lua/plugins/configs/lualine.lua
@@ -7,7 +7,7 @@ local sep = "/"
 local function find_git_dir_for(dir)
 	while dir and dir ~= "" and dir ~= "/" do
 		local git_path = dir .. sep .. ".git"
-		local stat = vim.loop.fs_stat(git_path)
+		local stat = (vim.uv or vim.loop).fs_stat(git_path)
 		if stat then
 			if stat.type == "directory" then
 				return git_path
@@ -86,7 +86,7 @@ return function()
 					-- ref: https://gist.github.com/shadmansaleh/cd526bc166237a5cbd51429cc1f6291b
 					function()
 						local msg = "No Active Lsp"
-						local buf_ft = vim.api.nvim_buf_get_option(0, "filetype")
+						local buf_ft = vim.bo.filetype
 						local clients = vim.lsp.get_clients()
 						if next(clients) == nil then
 							return msg

--- a/tests/deprecated_api.sh
+++ b/tests/deprecated_api.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Regression: keep the config free of nvim APIs deprecated by 0.11/0.12-dev.
+# Each emits a deprecation warning (and is scheduled for removal):
+#   - vim.loop.*       -> use (vim.uv or vim.loop)
+#   - vim.api.nvim_{buf,win}_{get,set}_option / nvim_{get,set}_option
+#                      -> use vim.bo / vim.wo / vim.o (or nvim_*_option_value)
+#   - vim.highlight.*  -> renamed to the vim.hl namespace in 0.11
+# The (vim.uv or vim.loop) and (vim.hl or vim.highlight) fallback forms are
+# allowed; only the bare deprecated access is rejected. nvim_*_option_value is
+# the modern form and is intentionally not matched (the \b stops before "_value").
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+ROOT="$REPO_ROOT/.config/nvim"
+status=0
+
+report() {
+  echo "deprecated API still present ($1):" >&2
+  echo "$2" >&2
+  status=1
+}
+
+hits="$(grep -rnE 'vim\.loop\b' "$ROOT/init.lua" "$ROOT/lua" | grep -v 'vim\.uv or vim\.loop' || true)"
+[ -n "$hits" ] && report "vim.loop -> (vim.uv or vim.loop)" "$hits"
+
+hits="$(grep -rnE 'nvim_(buf|win)_(get|set)_option\b|nvim_(get|set)_option\b' "$ROOT/init.lua" "$ROOT/lua" || true)"
+[ -n "$hits" ] && report "nvim_*_option -> vim.bo/vim.wo/vim.o" "$hits"
+
+hits="$(grep -rnE 'vim\.highlight\b' "$ROOT/init.lua" "$ROOT/lua" | grep -v 'vim\.hl or vim\.highlight' || true)"
+[ -n "$hits" ] && report "vim.highlight -> vim.hl" "$hits"
+
+exit "$status"


### PR DESCRIPTION
## What

While reviewing the codebase for issues left over after the recent migrations (telescope→snacks, nvim-cmp→blink.cmp, common→config), I found three call sites using nvim APIs that emit deprecation warnings on 0.11/0.12-dev and are scheduled for removal:

| File | Before | After |
| --- | --- | --- |
| `lua/plugins/configs/lualine.lua:10` | `vim.loop.fs_stat` | `(vim.uv or vim.loop).fs_stat` |
| `lua/plugins/configs/lualine.lua:89` | `vim.api.nvim_buf_get_option(0, "filetype")` | `vim.bo.filetype` |
| `lua/config/autocmds.lua:10` | `vim.highlight.on_yank` (command string) | `(vim.hl or vim.highlight).on_yank` (callback) |

The `(vim.uv or vim.loop)` fallback already exists in `init.lua`; this just makes the rest of the config consistent. The yank-highlight autocmd is converted from a `command` string to a `callback`, keeping its silent behavior via `pcall`.

## Regression guard

Adds `tests/deprecated_api.sh` (same grep-guard style as `tests/lspconfig.sh`) that rejects reintroduction of these bare deprecated calls, while allowing the `(vim.uv or vim.loop)` / `(vim.hl or vim.highlight)` fallback forms and the modern `nvim_*_option_value` getters.

## Test plan

- `bash tests/run.sh` → exit 0 (all suites incl. the new `deprecated_api.sh`).
- Guard sanity-checked: temporarily reintroducing a deprecated call makes it fail; reverting makes it pass.
- Headless runtime check (config + lualine loaded): the changed paths execute live —
  - `(vim.uv or vim.loop).fs_stat(<cwd>/.git)` → `file`
  - `vim.bo.filetype` → `lua`
  - lualine refresh + yank-highlight callback run with no error
  - **0 deprecation warnings** triggered while exercising all three paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)