### PR TITLE
fix(nvim): replace deprecated vim.diagnostic.goto_next/prev with jump()

### DIFF
--- a/.config/nvim/lua/plugins/configs/lspconfig.lua
+++ b/.config/nvim/lua/plugins/configs/lspconfig.lua
@@ -26,8 +26,14 @@ return function()
 			vim.keymap.set("n", "ga", vim.lsp.buf.code_action, bufopts)
 			vim.keymap.set("n", "gi", vim.lsp.buf.implementation, bufopts)
 
-			vim.keymap.set("n", "]d", vim.diagnostic.goto_next, bufopts)
-			vim.keymap.set("n", "[d", vim.diagnostic.goto_prev, bufopts)
+			-- goto_next/goto_prev were deprecated in 0.11 in favor of jump();
+			-- float = true keeps the old behavior of showing the diagnostic.
+			vim.keymap.set("n", "]d", function()
+				vim.diagnostic.jump({ count = 1, float = true })
+			end, bufopts)
+			vim.keymap.set("n", "[d", function()
+				vim.diagnostic.jump({ count = -1, float = true })
+			end, bufopts)
 		end,
 	})
 

--- a/tests/deprecated_api.sh
+++ b/tests/deprecated_api.sh
@@ -5,6 +5,7 @@
 #   - vim.api.nvim_{buf,win}_{get,set}_option / nvim_{get,set}_option
 #                      -> use vim.bo / vim.wo / vim.o (or nvim_*_option_value)
 #   - vim.highlight.*  -> renamed to the vim.hl namespace in 0.11
+#   - vim.diagnostic.goto_{next,prev} -> vim.diagnostic.jump({ count = ±1 })
 # The (vim.uv or vim.loop) and (vim.hl or vim.highlight) fallback forms are
 # allowed; only the bare deprecated access is rejected. nvim_*_option_value is
 # the modern form and is intentionally not matched (the \b stops before "_value").
@@ -28,5 +29,8 @@ hits="$(grep -rnE 'nvim_(buf|win)_(get|set)_option\b|nvim_(get|set)_option\b' "$
 
 hits="$(grep -rnE 'vim\.highlight\b' "$ROOT/init.lua" "$ROOT/lua" | grep -v 'vim\.hl or vim\.highlight' || true)"
 [ -n "$hits" ] && report "vim.highlight -> vim.hl" "$hits"
+
+hits="$(grep -rnE 'vim\.diagnostic\.goto_(next|prev)\b' "$ROOT/init.lua" "$ROOT/lua" || true)"
+[ -n "$hits" ] && report "vim.diagnostic.goto_next/prev -> vim.diagnostic.jump" "$hits"
 
 exit "$status"


### PR DESCRIPTION
goto_next/goto_prev were deprecated in Neovim 0.11; invoking ]d / [d
printed a deprecation warning. Switch to vim.diagnostic.jump({ count = ±1,
float = true }) (float keeps the old auto-show-diagnostic behavior) and add
a static regression check to tests/deprecated_api.sh.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
