### PR TITLE
refactor(config): モジュール化 + 欠落キーマップ修正

### DIFF
--- a/.config/nvim/lua/plugins/configs/bufferline.lua
+++ b/.config/nvim/lua/plugins/configs/bufferline.lua
@@ -1,0 +1,42 @@
+-- bufferline.nvim opts, extracted from plugins/ui.lua.
+--
+-- Tab page bar: shows Vim tabs (each tab ≈ a worktree in this config).
+-- Labels render the tab's cwd basename so a worktree tab reads as the
+-- branch/dir name (e.g. `add_tab_bar_plugin`) instead of the active buffer.
+return {
+	options = {
+		mode = "tabs",
+		style_preset = "default",
+		-- Prefix each tab with its ordinal (1., 2., …) so it doubles as
+		-- the `<n>gt` target. In tabs mode the ordinal equals the tab's
+		-- position, i.e. the number Vim uses for `:tabnext`.
+		numbers = "ordinal",
+		diagnostics = "nvim_lsp",
+		show_buffer_close_icons = false,
+		show_close_icon = false,
+		separator_style = "thin",
+		always_show_bufferline = true,
+		indicator = { style = "underline" },
+		name_formatter = function(opts)
+			-- Closing a tab can cause bufferline to re-render with a
+			-- stale `tabnr` that no longer exists. `vim.fn.getcwd(-1, tabnr)`
+			-- raises E5000 in that case, surfacing as E5108. Guard with a
+			-- range check and pcall, falling back to the buffer name.
+			local tabnr = opts.tabnr
+			if tabnr and tabnr >= 1 and tabnr <= vim.fn.tabpagenr("$") then
+				local ok, cwd = pcall(vim.fn.getcwd, -1, tabnr)
+				if ok then
+					local label = vim.fn.fnamemodify(cwd, ":t")
+					if label ~= "" then
+						local ok_notif, notif = pcall(require, "claude_workflow")
+						if ok_notif and notif.pending(cwd) then
+							label = "● " .. label
+						end
+						return label
+					end
+				end
+			end
+			return opts.name
+		end,
+	},
+}

--- a/.config/nvim/lua/plugins/configs/oil.lua
+++ b/.config/nvim/lua/plugins/configs/oil.lua
@@ -1,0 +1,31 @@
+-- oil.nvim config, extracted from plugins/ui.lua.
+return function()
+	local oil = require("oil")
+
+	oil.setup({
+		keymaps = {
+			["q"] = { "actions.close", mode = "n" },
+			["<C-d>"] = "actions.preview_scroll_down",
+			["<C-u>"] = "actions.preview_scroll_up",
+			["<leader>ff"] = {
+				function()
+					Snacks.picker.files({
+						cwd = require("oil").get_current_dir(),
+					})
+				end,
+				mode = "n",
+				nowait = true,
+				desc = "Find files in the current directory",
+			},
+		},
+	})
+
+	vim.api.nvim_create_autocmd("User", {
+		pattern = "OilEnter",
+		callback = vim.schedule_wrap(function(args)
+			if vim.api.nvim_get_current_buf() == args.data.buf and oil.get_cursor_entry() then
+				oil.open_preview()
+			end
+		end),
+	})
+end

--- a/.config/nvim/lua/plugins/configs/pickers.lua
+++ b/.config/nvim/lua/plugins/configs/pickers.lua
@@ -66,6 +66,12 @@ function M.setup()
 		Snacks.picker.grep({ hidden = true })
 	end, { noremap = true, silent = true, desc = "Live grep" })
 
+	-- Open the current file/line on the git host (snacks gitbrowse is enabled but
+	-- previously had no keymap).
+	vim.keymap.set({ "n", "v" }, "<Leader>go", function()
+		Snacks.gitbrowse()
+	end, { noremap = true, silent = true, desc = "Git: open in browser" })
+
 	-- `;` lists only the current tab's buffers (own per-tab tracking, not
 	-- telescope's path-based cwd_only) so worktree tabs don't bleed into each
 	-- other even when they share a cwd.

--- a/.config/nvim/lua/plugins/configs/snacks.lua
+++ b/.config/nvim/lua/plugins/configs/snacks.lua
@@ -1,0 +1,43 @@
+-- snacks.nvim config, extracted from plugins/editor.lua to keep the spec thin
+-- and match the configs/ module layout used by lspconfig/lualine/pickers.
+--
+-- Snacks is loaded at startup (lazy = false), so the Snacks-backed pickers and
+-- the per-tab buffer tracking they rely on are registered here via
+-- plugins.configs.pickers. telescope is fully removed: every picker
+-- (files/grep/buffers, worktrees) now runs on Snacks.picker.
+local M = {}
+
+M.opts = {
+	bufdelete = { enabled = true },
+	dashboard = { enabled = false },
+	gh = { enabled = true },
+	git = { enabled = true },
+	gitbrowse = { enabled = true },
+	indent = { enabled = true },
+	input = { enabled = true },
+	picker = {
+		enabled = true,
+		win = {
+			input = {
+				keys = {
+					["<C-p>"] = { "history_back", mode = { "i", "n" } },
+					["<C-n>"] = { "history_forward", mode = { "i", "n" } },
+				},
+			},
+		},
+	},
+	notifier = { enabled = true },
+	quickfile = { enabled = true },
+	scope = { enabled = true },
+	-- scroll = { enabled = true },
+	statuscolumn = { enabled = true },
+	terminal = { enabled = true },
+	words = { enabled = true },
+}
+
+function M.config(_, opts)
+	require("snacks").setup(opts)
+	require("plugins.configs.pickers").setup()
+end
+
+return M

--- a/.config/nvim/lua/plugins/configs/treesitter.lua
+++ b/.config/nvim/lua/plugins/configs/treesitter.lua
@@ -1,0 +1,61 @@
+-- nvim-treesitter config, extracted from plugins/ui.lua.
+return function()
+	-- archived nvim-treesitter master の query_predicates が Neovim 0.10+ の
+	-- TSMatch 新形式 (TSNode[]) に未対応で、vim-matchup 経由で E5108 が出るため
+	-- 該当 directive を上書きする。
+	require("config.treesitter_compat").apply()
+
+	require("nvim-treesitter.configs").setup({
+		ensure_installed = {
+			"ruby",
+			"javascript",
+			"lua",
+			"vim",
+			"vimdoc",
+			"query",
+			"typescript",
+			"tsx",
+			"json",
+			"yaml",
+			"html",
+			"css",
+			"scss",
+			"bash",
+			"python",
+			"go",
+			"rust",
+			"toml",
+			"jsonc",
+			"dockerfile",
+		},
+		sync_install = false,
+		auto_install = true,
+		ignore_install = {},
+		modules = {},
+		matchup = {
+			enable = true, -- mandatory, false will disable the whole extension
+		},
+		autotag = {
+			enable = true,
+		},
+		highlight = {
+			enable = true,
+		},
+		indent = {
+			enable = true,
+		},
+		endwise = {
+			enable = true,
+		},
+		textobjects = {
+			move = {
+				enable = true,
+				set_jumps = true,
+			},
+			select = {
+				enable = true,
+				lookahead = true,
+			},
+		},
+	})
+end

--- a/.config/nvim/lua/plugins/editor.lua
+++ b/.config/nvim/lua/plugins/editor.lua
@@ -28,41 +28,10 @@ return {
 		"folke/snacks.nvim",
 		priority = 1000,
 		lazy = false,
-		-- Snacks is loaded at startup, so the Snacks-backed pickers and the
-		-- per-tab buffer tracking they rely on are registered here. telescope is
-		-- fully removed: every picker (files/grep/buffers, worktrees, server) now
-		-- runs on Snacks.picker.
-		config = function(_, opts)
-			require("snacks").setup(opts)
-			require("plugins.configs.pickers").setup()
-		end,
-		opts = {
-			bufdelete = { enabled = true },
-			dashboard = { enabled = false },
-			gh = { enabled = true },
-			git = { enabled = true },
-			gitbrowse = { enabled = true },
-			indent = { enabled = true },
-			input = { enabled = true },
-			picker = {
-				enabled = true,
-				win = {
-					input = {
-						keys = {
-							["<C-p>"] = { "history_back", mode = { "i", "n" } },
-							["<C-n>"] = { "history_forward", mode = { "i", "n" } },
-						},
-					},
-				},
-			},
-			notifier = { enabled = true },
-			quickfile = { enabled = true },
-			scope = { enabled = true },
-			-- scroll = { enabled = true },
-			statuscolumn = { enabled = true },
-			terminal = { enabled = true },
-			words = { enabled = true },
-		},
+		-- opts + config (including the Snacks-backed picker registration) live in
+		-- plugins.configs.snacks to keep this spec thin.
+		opts = require("plugins.configs.snacks").opts,
+		config = require("plugins.configs.snacks").config,
 	},
 	{
 		"kylechui/nvim-surround",
@@ -196,6 +165,7 @@ return {
 		opts = {
 			preset = "modern",
 			spec = {
+				{ "<leader>c", group = "claude" },
 				{ "<leader>f", group = "find" },
 				{ "<leader>g", group = "git" },
 				{ "<leader>gw", group = "worktree" },

--- a/.config/nvim/lua/plugins/git.lua
+++ b/.config/nvim/lua/plugins/git.lua
@@ -1,7 +1,13 @@
 return {
 	{
 		"NeogitOrg/neogit",
-		event = "VeryLazy",
+		-- Loaded on demand: the `:Neogit` command or the <leader>gg keymap. It was
+		-- previously `event = "VeryLazy"` (eager at startup) with no keymap, so the
+		-- only way to open it was typing `:Neogit`.
+		cmd = "Neogit",
+		keys = {
+			{ "<leader>gg", "<cmd>Neogit<cr>", desc = "Git: Neogit status" },
+		},
 		version = "*",
 		dependencies = {
 			"nvim-lua/plenary.nvim", -- required
@@ -36,7 +42,7 @@ return {
 		config = function()
 			require("git_worktree").setup({
 				cleanup_buffers = true, -- Clean up old buffers when switching
-        gh_cmd = "~/bin/gh",
+				gh_cmd = "~/bin/gh",
 				worktreeinclude_file = ".worktreeinclude", -- Copy paths listed here into new worktrees
 			})
 		end,

--- a/.config/nvim/lua/plugins/ui.lua
+++ b/.config/nvim/lua/plugins/ui.lua
@@ -10,66 +10,7 @@ return {
 			"nvim-treesitter/nvim-treesitter-textobjects",
 		},
 		build = ":TSUpdate",
-		config = function()
-			-- archived nvim-treesitter master の query_predicates が Neovim 0.10+ の
-			-- TSMatch 新形式 (TSNode[]) に未対応で、vim-matchup 経由で E5108 が出るため
-			-- 該当 directive を上書きする。
-			require("config.treesitter_compat").apply()
-
-			require("nvim-treesitter.configs").setup({
-				ensure_installed = {
-					"ruby",
-					"javascript",
-					"lua",
-					"vim",
-					"vimdoc",
-					"query",
-					"typescript",
-					"tsx",
-					"json",
-					"yaml",
-					"html",
-					"css",
-					"scss",
-					"bash",
-					"python",
-					"go",
-					"rust",
-					"toml",
-					"jsonc",
-					"dockerfile",
-				},
-				sync_install = false,
-				auto_install = true,
-				ignore_install = {},
-				modules = {},
-				matchup = {
-					enable = true, -- mandatory, false will disable the whole extension
-				},
-				autotag = {
-					enable = true,
-				},
-				highlight = {
-					enable = true,
-				},
-				indent = {
-					enable = true,
-				},
-				endwise = {
-					enable = true,
-				},
-				textobjects = {
-					move = {
-						enable = true,
-						set_jumps = true,
-					},
-					select = {
-						enable = true,
-						lookahead = true,
-					},
-				},
-			})
-		end,
+		config = require("plugins.configs.treesitter"),
 	},
 	{
 		"EdenEast/nightfox.nvim",
@@ -91,36 +32,12 @@ return {
 		"stevearc/oil.nvim",
 		event = "BufReadPost",
 		dependencies = { { "echasnovski/mini.icons", opts = {} } },
-		config = function()
-			local oil = require("oil")
-
-			oil.setup({
-				keymaps = {
-					["q"] = { "actions.close", mode = "n" },
-					["<C-d>"] = "actions.preview_scroll_down",
-					["<C-u>"] = "actions.preview_scroll_up",
-					["<leader>ff"] = {
-						function()
-							Snacks.picker.files({
-								cwd = require("oil").get_current_dir(),
-							})
-						end,
-						mode = "n",
-						nowait = true,
-						desc = "Find files in the current directory",
-					},
-				},
-			})
-
-			vim.api.nvim_create_autocmd("User", {
-				pattern = "OilEnter",
-				callback = vim.schedule_wrap(function(args)
-					if vim.api.nvim_get_current_buf() == args.data.buf and oil.get_cursor_entry() then
-						oil.open_preview()
-					end
-				end),
-			})
-		end,
+		-- `-` opens oil at the current file's parent dir (oil's idiomatic entry
+		-- point); previously oil had a full config but no way to open it.
+		keys = {
+			{ "-", "<cmd>Oil<cr>", mode = "n", desc = "Oil: open parent dir" },
+		},
+		config = require("plugins.configs.oil"),
 	},
 	-- {
 	-- 	"lukas-reineke/indent-blankline.nvim",
@@ -135,50 +52,11 @@ return {
 		event = "BufReadPost",
 		opts = {},
 	},
-	-- Tab page bar: shows Vim tabs (each tab ≈ a worktree in this config).
-	-- Labels render the tab's cwd basename so a worktree tab reads as the
-	-- branch/dir name (e.g. `add_tab_bar_plugin`) instead of the active buffer.
 	{
 		"akinsho/bufferline.nvim",
 		version = "*",
 		event = "VeryLazy",
 		dependencies = { "nvim-tree/nvim-web-devicons" },
-		opts = {
-			options = {
-				mode = "tabs",
-				style_preset = "default",
-				-- Prefix each tab with its ordinal (1., 2., …) so it doubles as
-				-- the `<n>gt` target. In tabs mode the ordinal equals the tab's
-				-- position, i.e. the number Vim uses for `:tabnext`.
-				numbers = "ordinal",
-				diagnostics = "nvim_lsp",
-				show_buffer_close_icons = false,
-				show_close_icon = false,
-				separator_style = "thin",
-				always_show_bufferline = true,
-				indicator = { style = "underline" },
-				name_formatter = function(opts)
-					-- Closing a tab can cause bufferline to re-render with a
-					-- stale `tabnr` that no longer exists. `vim.fn.getcwd(-1, tabnr)`
-					-- raises E5000 in that case, surfacing as E5108. Guard with a
-					-- range check and pcall, falling back to the buffer name.
-					local tabnr = opts.tabnr
-					if tabnr and tabnr >= 1 and tabnr <= vim.fn.tabpagenr("$") then
-						local ok, cwd = pcall(vim.fn.getcwd, -1, tabnr)
-						if ok then
-							local label = vim.fn.fnamemodify(cwd, ":t")
-							if label ~= "" then
-								local ok_notif, notif = pcall(require, "claude_workflow")
-								if ok_notif and notif.pending(cwd) then
-									label = "● " .. label
-								end
-								return label
-							end
-						end
-					end
-					return opts.name
-				end,
-			},
-		},
+		opts = require("plugins.configs.bufferline"),
 	},
 }

--- a/tests/config_modularization.sh
+++ b/tests/config_modularization.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Guards the editor brush-up:
+#   * the snacks/treesitter/oil/bufferline configs extracted into
+#     plugins/configs/ keep their expected shape (so the thin specs in
+#     editor.lua/ui.lua that `require` them stay valid), and
+#   * the keymaps added during the same pass stay wired:
+#       <leader>gg  -> Neogit         (lazy `keys` stub)
+#       -           -> Oil            (lazy `keys` stub)
+#       <leader>go  -> Snacks.gitbrowse (registered at startup)
+# Asserting by `desc` sidesteps <leader> expansion in maparg().
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+# 1. Extracted config modules load and have the shape the specs depend on.
+run_nv \
+  -c 'lua local s = require("plugins.configs.snacks")
+       if type(s.opts) ~= "table" then print("snacks.opts not a table"); vim.cmd("cquit") end
+       if type(s.config) ~= "function" then print("snacks.config not a function"); vim.cmd("cquit") end
+       if type(require("plugins.configs.treesitter")) ~= "function" then print("treesitter config not a function"); vim.cmd("cquit") end
+       if type(require("plugins.configs.oil")) ~= "function" then print("oil config not a function"); vim.cmd("cquit") end
+       local bo = require("plugins.configs.bufferline")
+       if type(bo) ~= "table" or bo.options == nil then print("bufferline opts missing options"); vim.cmd("cquit") end
+       if bo.options.numbers ~= "ordinal" then print("bufferline numbers != ordinal"); vim.cmd("cquit") end
+       if type(bo.options.name_formatter) ~= "function" then print("bufferline name_formatter not a function"); vim.cmd("cquit") end' \
+  -c qa
+
+# 2. The newly-added normal-mode keymaps are registered (matched by desc).
+run_nv \
+  -c 'lua local want = { ["Git: Neogit status"] = false, ["Oil: open parent dir"] = false, ["Git: open in browser"] = false }
+       for _, m in ipairs(vim.api.nvim_get_keymap("n")) do
+         if m.desc and want[m.desc] == false then want[m.desc] = true end
+       end
+       for d, found in pairs(want) do
+         if not found then print("missing keymap with desc: " .. d); vim.cmd("cquit") end
+       end' \
+  -c qa


### PR DESCRIPTION
## 概要

nvim 設定を見直し調査し、設計上の歪みを是正。プラグインの利用適正化・設定のモジュール化・欠落キーマップの追加を行う。
(未使用プラグインの削除はユーザ判断で今回スコープ外)

## 変更内容

### B. キーマップ欠落・lazy 適正化
- **Neogit**: `event=VeryLazy`(起動時ロード/keymap無し、`:Neogit` 手打ちのみ)→ `cmd="Neogit"` + `<leader>gg`
- **oil**: 開く手段が無かったので `-` → `:Oil`(親ディレクトリ)を追加
- **snacks gitbrowse**: 有効だが keymap が無かったので `<leader>go` を追加

### C. which-key 整合
- `<leader>c` = "claude" グループを spec に追加(cc/co/cC/cr/cx/cs が未グループだった)

### D. 設定のモジュール化(`configs/` へ切り出し)
inline の巨大設定を分離し、spec は `require` で薄く。既存の lspconfig/lualine/pickers と一貫させる。
- `plugins/configs/snacks.lua`(`.opts` + `.config`)
- `plugins/configs/treesitter.lua`
- `plugins/configs/oil.lua`
- `plugins/configs/bufferline.lua`

### その他
- pre-existing の stylua 違反(`git.lua` の `gh_cmd` 行のスペース字下げ)を修正

## テスト
- 新規 `tests/config_modularization.sh`: 抽出4モジュールの shape + 追加キーマップ3件を desc で検証(red/green 確認済み)
- `bash tests/run.sh` → 全テスト合格(EXIT=0)
- `stylua --check .` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)