### PR TITLE
feat(plugins): install midori.nvim via lazy

### DIFF
--- a/.config/nvim/lua/plugins/editor.lua
+++ b/.config/nvim/lua/plugins/editor.lua
@@ -169,6 +169,7 @@ return {
 				{ "<leader>f", group = "find" },
 				{ "<leader>g", group = "git" },
 				{ "<leader>gw", group = "worktree" },
+				{ "<leader>m", group = "midori" },
 				{ "<leader>s", group = "flash" },
 				{ "<leader>t", group = "test" },
 				{ "<leader>x", group = "trouble" },

--- a/.config/nvim/lua/plugins/ui.lua
+++ b/.config/nvim/lua/plugins/ui.lua
@@ -59,4 +59,14 @@ return {
 		dependencies = { "nvim-tree/nvim-web-devicons" },
 		opts = require("plugins.configs.bufferline"),
 	},
+	{
+		"mitubaEX/midori.nvim",
+		ft = "markdown",
+		cmd = { "MidoriView", "MidoriToggle", "MidoriClose" },
+		keys = {
+			{ "<leader>mv", "<cmd>MidoriView<cr>", desc = "Midori: view markdown" },
+			{ "<leader>mt", "<cmd>MidoriToggle<cr>", desc = "Midori: toggle reader" },
+		},
+		opts = {},
+	},
 }


### PR DESCRIPTION
## Summary
- Adds `mitubaEX/midori.nvim` lazy spec (markdown ft / `:Midori*` cmd / `<leader>m{v,t}` keys)
- Adds `<leader>m` → `midori` group to which-key

Reader-only markdown viewer with syntax-highlighted code blocks and mermaid graph rendering. Repo: https://github.com/mitubaEX/midori.nvim

## Test plan
- [x] `bash tests/run.sh` → EXIT=0 (lazy resolves spec, all existing tests pass)
- [x] `lazy install` headless → clones into `.local/share/nvim/lazy/midori.nvim`
- [x] `:MidoriView` on a sample markdown → `ft=midori`, `modifiable=false`, headings/lists/code/mermaid all rendered
- [ ] Manual verify in real nvim session

🤖 Generated with [Claude Code](https://claude.com/claude-code)