### PR TITLE
feat(plugins): add md-render.nvim for in-terminal markdown preview

### DIFF
--- a/.config/nvim/lua/plugins/lang.lua
+++ b/.config/nvim/lua/plugins/lang.lua
@@ -71,4 +71,15 @@ return {
 			require("headlines").setup()
 		end,
 	},
+	{
+		"delphinus/md-render.nvim",
+		version = "*",
+		ft = "markdown",
+		cmd = "MdRender",
+		keys = {
+			{ "<leader>mp", "<Plug>(md-render-preview)", desc = "Markdown preview (toggle)" },
+			{ "<leader>mt", "<Plug>(md-render-preview-tab)", desc = "Markdown preview in tab (toggle)" },
+			{ "<leader>md", "<Plug>(md-render-demo)", desc = "Markdown render demo" },
+		},
+	},
 }

--- a/tests/md_render.sh
+++ b/tests/md_render.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Guards md-render.nvim wiring:
+#   * the <Plug>(md-render-*) keymaps in lang.lua are registered as lazy keys
+#     (desc match avoids <leader> expansion fragility in maparg()).
+#   * the :MdRender command becomes available after the plugin is loaded
+#     via its `cmd` trigger.
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+# 1. The three normal-mode keymaps registered via lazy `keys` exist.
+run_nv \
+  -c 'lua local want = {
+        ["Markdown preview (toggle)"] = false,
+        ["Markdown preview in tab (toggle)"] = false,
+        ["Markdown render demo"] = false,
+      }
+       for _, m in ipairs(vim.api.nvim_get_keymap("n")) do
+         if m.desc and want[m.desc] == false then want[m.desc] = true end
+       end
+       for d, found in pairs(want) do
+         if not found then print("missing keymap with desc: " .. d); vim.cmd("cquit") end
+       end' \
+  -c qa
+
+# 2. Triggering the lazy load surfaces the :MdRender command.
+run_nv \
+  -c 'lua require("lazy").load({ plugins = { "md-render.nvim" } })
+       if vim.fn.exists(":MdRender") ~= 2 then print("missing command: MdRender"); vim.cmd("cquit") end' \
+  -c qa


### PR DESCRIPTION
Registers delphinus/md-render.nvim under markdown ft / :MdRender cmd with
<leader>m{p,t,d} mapped to the <Plug>(md-render-*) preview/tab/demo
toggles, plus a tests/md_render.sh guard for the keymaps and command.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
