### PR TITLE
feat(md-render): switch to vsplit-only keymap

### DIFF
--- a/.config/nvim/lua/plugins/lang.lua
+++ b/.config/nvim/lua/plugins/lang.lua
@@ -77,9 +77,7 @@ return {
 		ft = "markdown",
 		cmd = "MdRender",
 		keys = {
-			{ "<leader>mp", "<Plug>(md-render-preview)", desc = "Markdown preview (toggle)" },
-			{ "<leader>mt", "<Plug>(md-render-preview-tab)", desc = "Markdown preview in tab (toggle)" },
-			{ "<leader>md", "<Plug>(md-render-demo)", desc = "Markdown render demo" },
+			{ "<leader>ms", "<cmd>vert MdRender split<cr>", desc = "Markdown preview (vsplit)" },
 		},
 	},
 }

--- a/tests/md_render.sh
+++ b/tests/md_render.sh
@@ -7,15 +7,22 @@
 set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 
-# 1. The three normal-mode keymaps registered via lazy `keys` exist.
+# 1. The vsplit-preview keymap registered via lazy `keys` exists, and the
+#    previously-removed keymaps (mp/mt/md) are NOT present.
 run_nv \
   -c 'lua local want = {
-        ["Markdown preview (toggle)"] = false,
-        ["Markdown preview in tab (toggle)"] = false,
-        ["Markdown render demo"] = false,
+        ["Markdown preview (vsplit)"] = false,
       }
+       local forbidden = {
+         ["Markdown preview (toggle)"] = true,
+         ["Markdown preview in tab (toggle)"] = true,
+         ["Markdown render demo"] = true,
+       }
        for _, m in ipairs(vim.api.nvim_get_keymap("n")) do
          if m.desc and want[m.desc] == false then want[m.desc] = true end
+         if m.desc and forbidden[m.desc] then
+           print("unexpected keymap still present: " .. m.desc); vim.cmd("cquit")
+         end
        end
        for d, found in pairs(want) do
          if not found then print("missing keymap with desc: " .. d); vim.cmd("cquit") end


### PR DESCRIPTION
## Summary
- `:MdRender split` が `:vert` modifier を honour するので、vsplit 用に `<leader>ms` → `<cmd>vert MdRender split<cr>` を追加。
- 実際には使っていなかった floating / tab / demo の keymap (`<leader>mp` / `<leader>mt` / `<leader>md`) を削除。
- `tests/md_render.sh` を更新し、新しい desc の存在と、削除した 3 つの desc が残っていないこと両方を検証 (red → green で確認済み)。

## Test plan
- [x] `bash tests/md_render.sh` 単体: red → 実装後 green
- [x] `bash tests/run.sh` フルテスト: pass
- [x] headless で `:vert MdRender split` を実行し、source / render の window が横並び (col=0 と col=40) になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)