### PR TITLE
feat(plugins): add edaha.nvim

### DIFF
--- a/.config/nvim/lua/plugins/git.lua
+++ b/.config/nvim/lua/plugins/git.lua
@@ -139,6 +139,14 @@ return {
 			{ "<leader>gwX", "<cmd>GitWorktreeCleanup<CR>", desc = "Worktree: cleanup all" },
 		},
 	},
+	{
+		-- Ollama (qwen3.5:4b) で日本語の作業内容から英語 kebab-case ブランチ名を
+		-- 生成して `git worktree add` まで一発で実行する。AI クラウド課金なし。
+		-- 公開コマンド: :Edaha <desc> / :EdahaName <desc> / :EdahaList
+		"mitubaEX/edaha.nvim",
+		cmd = { "Edaha", "EdahaName", "EdahaList" },
+		opts = {},
+	},
 
 	-- utils
 	{


### PR DESCRIPTION
## Summary
- Add `mitubaEX/edaha.nvim` to `plugins/git.lua` as a cmd-only lazy load (`:Edaha` / `:EdahaName` / `:EdahaList`).
- `opts = {}` keeps upstream defaults (model `qwen2.5:1.5b`, worktree root `../<repo>.worktrees/`).
- No keymap added — `<leader>gw*` is fully used by `git_worktree.nvim`, and we don't want Ollama warming up on startup; `:Edaha <日本語>` is invoked directly from cmdline.

## Test plan
- [ ] `:Lazy sync` installs edaha.nvim cleanly
- [ ] `:Edaha 認証周りのリファクタ` proposes a kebab-case branch and (on `y`) runs `git worktree add` + `:tcd`
- [ ] `:EdahaList` shows worktrees
- [ ] No startup-time ollama invocation (verify with `:Lazy profile`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)